### PR TITLE
Add documentation for exported wave classes

### DIFF
--- a/wave_sim/__init__.py
+++ b/wave_sim/__init__.py
@@ -1,3 +1,7 @@
+"""Public interface for the :mod:`wave_sim` package."""
+
+# Explicitly re-export the supported wave simulation classes so that external
+# users can simply do ``from wave_sim import PWaveSimulation``.
 from .base import WaveSimulation
 from .p_wave import PWaveSimulation
 from .s_wave import SWaveSimulation


### PR DESCRIPTION
## Summary
- document the public interface of `wave_sim`
- explain that explicit re-exports make it easy to import simulations

## Testing
- `python -m pip install -r requirements.txt` *(fails: unable to access SophT.git)*