### PR TITLE
Add specialized wave catalog with new wave classes

### DIFF
--- a/examples/collage.py
+++ b/examples/collage.py
@@ -1,5 +1,10 @@
 import os
-from wave_sim import PWaveSimulation, SWaveSimulation
+from wave_sim import (
+    SeismicPWaveSimulation,
+    SeismicSWaveSimulation,
+    InternalGravityWaveSimulation,
+    ElectromagneticWaveSimulation,
+)
 
 from matplotlib import pyplot as plt
 from matplotlib.animation import FuncAnimation
@@ -14,12 +19,13 @@ def run_and_save(sim, name, steps=100):
 
 def main():
     os.makedirs('output', exist_ok=True)
-    p_sim = PWaveSimulation(grid_size=100)
-    s_sim = SWaveSimulation(grid_size=100)
-    files = [
-        run_and_save(p_sim, os.path.join('output', 'p_wave')),
-        run_and_save(s_sim, os.path.join('output', 's_wave')),
+    demos = [
+        (SeismicPWaveSimulation(grid_size=100), 'p_wave'),
+        (SeismicSWaveSimulation(grid_size=100), 's_wave'),
+        (InternalGravityWaveSimulation(grid_size=100), 'gravity_wave'),
+        (ElectromagneticWaveSimulation(grid_size=100), 'em_wave'),
     ]
+    files = [run_and_save(sim, os.path.join('output', name)) for sim, name in demos]
     print('Generated files:', files)
 
 

--- a/wave_sim/__init__.py
+++ b/wave_sim/__init__.py
@@ -1,9 +1,19 @@
 from .base import WaveSimulation
 from .p_wave import PWaveSimulation
 from .s_wave import SWaveSimulation
+from .wave_catalog import (
+    SeismicPWaveSimulation,
+    SeismicSWaveSimulation,
+    InternalGravityWaveSimulation,
+    ElectromagneticWaveSimulation,
+)
 
 __all__ = [
     'WaveSimulation',
     'PWaveSimulation',
     'SWaveSimulation',
+    'SeismicPWaveSimulation',
+    'SeismicSWaveSimulation',
+    'InternalGravityWaveSimulation',
+    'ElectromagneticWaveSimulation',
 ]

--- a/wave_sim/wave_catalog.py
+++ b/wave_sim/wave_catalog.py
@@ -1,0 +1,66 @@
+import numpy as np
+from .base import WaveSimulation
+
+
+class SeismicPWaveSimulation(WaveSimulation):
+    """P-wave modeled via linear elasticity."""
+
+    def __init__(self, density=2500.0, bulk_modulus=30e9, **kwargs):
+        c = np.sqrt(bulk_modulus / density)
+        super().__init__(c=c, **kwargs)
+        self.density = density
+        self.bulk_modulus = bulk_modulus
+        self.initialize(amplitude=1.0)
+
+
+class SeismicSWaveSimulation(WaveSimulation):
+    """S-wave modeled via linear elasticity."""
+
+    def __init__(self, density=2500.0, shear_modulus=30e9, **kwargs):
+        c = np.sqrt(shear_modulus / density)
+        super().__init__(c=c, **kwargs)
+        self.density = density
+        self.shear_modulus = shear_modulus
+        self.initialize(amplitude=1.0)
+
+
+class InternalGravityWaveSimulation(WaveSimulation):
+    """Simplified internal gravity wave using a damping term."""
+
+    def __init__(self, density=1025.0, buoyancy_freq=0.01, damping=0.01, **kwargs):
+        c = 1.0 / buoyancy_freq
+        super().__init__(c=c, **kwargs)
+        self.density = density
+        self.buoyancy_freq = buoyancy_freq
+        self.damping = damping
+        self.initialize(amplitude=0.1)
+
+    def step(self):
+        c2 = (self.c * self.dt / self.dx) ** 2
+        laplacian = (
+            np.roll(self.u_curr, 1, axis=0)
+            + np.roll(self.u_curr, -1, axis=0)
+            + np.roll(self.u_curr, 1, axis=1)
+            + np.roll(self.u_curr, -1, axis=1)
+            - 4 * self.u_curr
+        )
+        u_next = ((2 - self.damping) * self.u_curr
+                  - (1 - self.damping) * self.u_prev
+                  + c2 * laplacian)
+        u_next[0, :] = 0
+        u_next[-1, :] = 0
+        u_next[:, 0] = 0
+        u_next[:, -1] = 0
+        self.u_prev, self.u_curr = self.u_curr, u_next
+        return u_next
+
+
+class ElectromagneticWaveSimulation(WaveSimulation):
+    """Electromagnetic wave solved via scalar wave equation."""
+
+    def __init__(self, permittivity=8.854e-12, permeability=4 * np.pi * 1e-7, **kwargs):
+        c = 1.0 / np.sqrt(permittivity * permeability)
+        super().__init__(c=c, **kwargs)
+        self.permittivity = permittivity
+        self.permeability = permeability
+        self.initialize(amplitude=1.0)


### PR DESCRIPTION
## Summary
- implement `wave_sim/wave_catalog.py` with several specialized solvers
- export the new classes from `wave_sim.__init__`
- update `examples/collage.py` to use the new classes

## Testing
- `python -m py_compile $(git ls-files '*.py')`