### PR TITLE
Add new wave categories and stub solvers

### DIFF
--- a/wave_sim/__init__.py
+++ b/wave_sim/__init__.py
@@ -7,6 +7,12 @@ from .wave_catalog import (
     AcousticWave,
     FluidSurfaceWave,
     ElectromagneticWave,
+    SeismicSurfaceWave,
+    GuidedWave,
+    AcousticMode,
+    FluidInternalWave,
+    EMWave,
+    MHDWave,
 )
 
 __all__ = [
@@ -18,4 +24,10 @@ __all__ = [
     'AcousticWave',
     'FluidSurfaceWave',
     'ElectromagneticWave',
+    'SeismicSurfaceWave',
+    'GuidedWave',
+    'AcousticMode',
+    'FluidInternalWave',
+    'EMWave',
+    'MHDWave',
 ]

--- a/wave_sim/acoustic_mode.py
+++ b/wave_sim/acoustic_mode.py
@@ -1,0 +1,10 @@
+from .base import WaveSimulation
+
+class AcousticMode(WaveSimulation):
+    """Acoustic mode in a resonant cavity."""
+
+    def __init__(self, source_func=None, **kwargs):
+        kwargs.setdefault("c", 0.9)
+        kwargs.setdefault("boundary", "reflective")
+        super().__init__(**kwargs)
+        self.initialize(amplitude=1.0, source_func=source_func)

--- a/wave_sim/em_solver.py
+++ b/wave_sim/em_solver.py
@@ -1,0 +1,12 @@
+class EMSolver:
+    """Placeholder solver for electromagnetic waves."""
+
+    def step(self, fields):
+        """Advance the electromagnetic field state.
+
+        Parameters
+        ----------
+        fields : any
+            Placeholder for field variables.
+        """
+        pass

--- a/wave_sim/em_wave.py
+++ b/wave_sim/em_wave.py
@@ -1,0 +1,12 @@
+from .base import WaveSimulation
+from .em_solver import EMSolver
+
+class EMWave(WaveSimulation):
+    """Simplified electromagnetic wave using a stub solver."""
+
+    def __init__(self, solver=None, source_func=None, **kwargs):
+        kwargs.setdefault("c", 1.0)
+        kwargs.setdefault("boundary", "periodic")
+        super().__init__(**kwargs)
+        self.solver = solver or EMSolver()
+        self.initialize(amplitude=1.0, source_func=source_func)

--- a/wave_sim/fluid_internal_wave.py
+++ b/wave_sim/fluid_internal_wave.py
@@ -1,0 +1,10 @@
+from .base import WaveSimulation
+
+class FluidInternalWave(WaveSimulation):
+    """Idealized internal wave within a stratified fluid."""
+
+    def __init__(self, source_func=None, **kwargs):
+        kwargs.setdefault("c", 0.3)
+        kwargs.setdefault("boundary", "absorbing")
+        super().__init__(**kwargs)
+        self.initialize(amplitude=1.0, source_func=source_func)

--- a/wave_sim/guided_wave.py
+++ b/wave_sim/guided_wave.py
@@ -1,0 +1,10 @@
+from .base import WaveSimulation
+
+class GuidedWave(WaveSimulation):
+    """Wave confined in a guiding structure."""
+
+    def __init__(self, source_func=None, **kwargs):
+        kwargs.setdefault("c", 0.8)
+        kwargs.setdefault("boundary", "reflective")
+        super().__init__(**kwargs)
+        self.initialize(amplitude=1.0, source_func=source_func)

--- a/wave_sim/mhd_solver.py
+++ b/wave_sim/mhd_solver.py
@@ -1,0 +1,12 @@
+class MHDSolver:
+    """Placeholder solver for magnetohydrodynamic waves."""
+
+    def step(self, state):
+        """Advance the MHD state variables.
+
+        Parameters
+        ----------
+        state : any
+            Placeholder for MHD variables.
+        """
+        pass

--- a/wave_sim/mhd_wave.py
+++ b/wave_sim/mhd_wave.py
@@ -1,0 +1,12 @@
+from .base import WaveSimulation
+from .mhd_solver import MHDSolver
+
+class MHDWave(WaveSimulation):
+    """Simplified MHD wave using a stub solver."""
+
+    def __init__(self, solver=None, source_func=None, **kwargs):
+        kwargs.setdefault("c", 1.0)
+        kwargs.setdefault("boundary", "periodic")
+        super().__init__(**kwargs)
+        self.solver = solver or MHDSolver()
+        self.initialize(amplitude=1.0, source_func=source_func)

--- a/wave_sim/surface_wave.py
+++ b/wave_sim/surface_wave.py
@@ -1,0 +1,10 @@
+from .base import WaveSimulation
+
+class SeismicSurfaceWave(WaveSimulation):
+    """Simplified seismic surface wave."""
+
+    def __init__(self, source_func=None, **kwargs):
+        kwargs.setdefault("c", 0.5)
+        kwargs.setdefault("boundary", "absorbing")
+        super().__init__(**kwargs)
+        self.initialize(amplitude=1.0, source_func=source_func)

--- a/wave_sim/wave_catalog.py
+++ b/wave_sim/wave_catalog.py
@@ -8,6 +8,12 @@ phenomena without needing to configure the base solver each time.
 """
 
 from .base import WaveSimulation
+from .surface_wave import SeismicSurfaceWave
+from .guided_wave import GuidedWave
+from .acoustic_mode import AcousticMode
+from .fluid_internal_wave import FluidInternalWave
+from .em_wave import EMWave
+from .mhd_wave import MHDWave
 
 
 # ---------------------------------------------------------------------------
@@ -127,4 +133,10 @@ __all__ = [
     "AcousticWave",
     "FluidSurfaceWave",
     "ElectromagneticWave",
+    "SeismicSurfaceWave",
+    "GuidedWave",
+    "AcousticMode",
+    "FluidInternalWave",
+    "EMWave",
+    "MHDWave",
 ]


### PR DESCRIPTION
## Summary
- add modules for surface, guided, acoustic mode, internal fluid, EM, and MHD waves
- stub out `EMSolver` and `MHDSolver`
- export new classes in `__init__` and `wave_catalog`

## Testing
- `python -m py_compile $(git ls-files '*.py')`