### PR TITLE
Add dynamic P/S/SH/SV wave solvers

### DIFF
--- a/wave_sim/__init__.py
+++ b/wave_sim/__init__.py
@@ -2,7 +2,7 @@
 
 from .base import WaveSimulation
 from .p_wave import PWaveSimulation
-from .s_wave import SWaveSimulation
+from .s_wave import SWaveSimulation, SHWaveSimulation, SVWaveSimulation
 from .wave_catalog import (
     PrimaryWave,
     SecondaryWave,
@@ -30,6 +30,8 @@ __all__ = [
     "WaveSimulation",
     "PWaveSimulation",
     "SWaveSimulation",
+    "SHWaveSimulation",
+    "SVWaveSimulation",
     "PrimaryWave",
     "SecondaryWave",
     "SHWave",

--- a/wave_sim/base.py
+++ b/wave_sim/base.py
@@ -28,6 +28,7 @@ class WaveSimulation:
         self.boundary = boundary
         self.u_prev = np.zeros((self.n, self.n))
         self.u_curr = np.zeros((self.n, self.n))
+        self.time = 0.0
         cfl = self.c * self.dt / self.dx
         if cfl > 1 / np.sqrt(2):
             warnings.warn(
@@ -59,6 +60,7 @@ class WaveSimulation:
         else:
             raise ValueError(f"Unknown boundary condition {self.boundary}")
         self.u_prev, self.u_curr = self.u_curr, u_next
+        self.time += self.dt
         return u_next
 
     def initialize(self, source_pos=None, amplitude=1.0, source_func=None):

--- a/wave_sim/p_wave.py
+++ b/wave_sim/p_wave.py
@@ -1,13 +1,60 @@
+import numpy as np
+
 from .base import WaveSimulation
 
 
 class PWaveSimulation(WaveSimulation):
-    """Simple representation of a seismic P-wave (compressional).
+    """Finite-difference propagator for a 2-D P-wave field."""
 
-    The propagation speed defaults to ``1.0`` which mirrors the reference
-    value used for the fastest body waves in elastic solids.
-    """
-
-    def __init__(self, source_func=None, **kwargs):
+    def __init__(self, f0=15.0, source_pos=None, source_func=None, **kwargs):
+        kwargs.setdefault("c", 3000.0)
+        kwargs.setdefault("dx", 5.0)
+        kwargs.setdefault("dt", 0.0005)
         super().__init__(**kwargs)
-        self.initialize(amplitude=1.0, source_func=source_func)
+        self.f0 = f0
+        if source_pos is None:
+            source_pos = (self.n // 2, self.n // 2)
+        self.source_pos = source_pos
+        self.initialize(amplitude=0.0, source_func=source_func)
+
+    @staticmethod
+    def ricker_wavelet(t, f0):
+        tau = 1.0 / f0
+        return (1.0 - 2.0 * (np.pi ** 2) * (f0 ** 2) * (t - tau) ** 2) * np.exp(
+            -(np.pi ** 2) * (f0 ** 2) * (t - tau) ** 2
+        )
+
+    def step(self):
+        c2 = (self.c * self.dt / self.dx) ** 2
+        laplacian = (
+            np.roll(self.u_curr, 1, axis=0)
+            + np.roll(self.u_curr, -1, axis=0)
+            + np.roll(self.u_curr, 1, axis=1)
+            + np.roll(self.u_curr, -1, axis=1)
+            - 4 * self.u_curr
+        )
+        u_next = 2 * self.u_curr - self.u_prev + c2 * laplacian
+
+        # Inject Ricker wavelet source
+        amp = self.ricker_wavelet(self.time, self.f0)
+        sx, sy = self.source_pos
+        u_next[sx, sy] += amp
+
+        if self.boundary == "reflective":
+            u_next[0, :] = 0
+            u_next[-1, :] = 0
+            u_next[:, 0] = 0
+            u_next[:, -1] = 0
+        elif self.boundary == "periodic":
+            pass
+        elif self.boundary == "absorbing":
+            u_next[0, :] = u_next[1, :]
+            u_next[-1, :] = u_next[-2, :]
+            u_next[:, 0] = u_next[:, 1]
+            u_next[:, -1] = u_next[:, -2]
+        else:
+            raise ValueError(f"Unknown boundary condition {self.boundary}")
+
+        self.u_prev, self.u_curr = self.u_curr, u_next
+        self.time += self.dt
+        return u_next

--- a/wave_sim/s_wave.py
+++ b/wave_sim/s_wave.py
@@ -1,14 +1,71 @@
+import numpy as np
+
 from .base import WaveSimulation
 
 
 class SWaveSimulation(WaveSimulation):
-    """Simple representation of a seismic S-wave (shear).
+    """Finite-difference solver for shear (S) waves."""
 
-    By default the wave speed is reduced to ``0.6`` to highlight that
-    shear waves travel slower than compressional waves in most solids.
-    """
-
-    def __init__(self, source_func=None, **kwargs):
-        kwargs.setdefault('c', 0.6)
+    def __init__(self, f0=15.0, source_pos=None, source_func=None, **kwargs):
+        kwargs.setdefault("c", 1500.0)
+        kwargs.setdefault("dx", 5.0)
+        kwargs.setdefault("dt", 0.0005)
         super().__init__(**kwargs)
-        self.initialize(amplitude=1.0, source_func=source_func)
+        self.f0 = f0
+        if source_pos is None:
+            source_pos = (self.n // 2, self.n // 2)
+        self.source_pos = source_pos
+        self.initialize(amplitude=0.0, source_func=source_func)
+
+    @staticmethod
+    def ricker_wavelet(t, f0):
+        tau = 1.0 / f0
+        return (1.0 - 2.0 * (np.pi ** 2) * (f0 ** 2) * (t - tau) ** 2) * np.exp(
+            -(np.pi ** 2) * (f0 ** 2) * (t - tau) ** 2
+        )
+
+    def step(self):
+        c2 = (self.c * self.dt / self.dx) ** 2
+        laplacian = (
+            np.roll(self.u_curr, 1, axis=0)
+            + np.roll(self.u_curr, -1, axis=0)
+            + np.roll(self.u_curr, 1, axis=1)
+            + np.roll(self.u_curr, -1, axis=1)
+            - 4 * self.u_curr
+        )
+        u_next = 2 * self.u_curr - self.u_prev + c2 * laplacian
+
+        amp = self.ricker_wavelet(self.time, self.f0)
+        sx, sy = self.source_pos
+        u_next[sx, sy] += amp
+
+        if self.boundary == "reflective":
+            u_next[0, :] = 0
+            u_next[-1, :] = 0
+            u_next[:, 0] = 0
+            u_next[:, -1] = 0
+        elif self.boundary == "periodic":
+            pass
+        elif self.boundary == "absorbing":
+            u_next[0, :] = u_next[1, :]
+            u_next[-1, :] = u_next[-2, :]
+            u_next[:, 0] = u_next[:, 1]
+            u_next[:, -1] = u_next[:, -2]
+        else:
+            raise ValueError(f"Unknown boundary condition {self.boundary}")
+
+        self.u_prev, self.u_curr = self.u_curr, u_next
+        self.time += self.dt
+        return u_next
+
+
+class SHWaveSimulation(SWaveSimulation):
+    """Horizontally polarised shear wave."""
+
+    pass
+
+
+class SVWaveSimulation(SWaveSimulation):
+    """Vertically polarised shear wave."""
+
+    pass

--- a/wave_sim/wave_catalog.py
+++ b/wave_sim/wave_catalog.py
@@ -7,46 +7,44 @@ the field with a unit impulse in the centre of the grid.
 """
 
 from .base import WaveSimulation
+from .p_wave import PWaveSimulation
+from .s_wave import SWaveSimulation, SHWaveSimulation, SVWaveSimulation
 
 
 ###############################################################################
 # SEISMIC BODY WAVES
 ###############################################################################
 
-class PrimaryWave(WaveSimulation):
+class PrimaryWave(PWaveSimulation):
     """Compressional body wave."""
 
     def __init__(self, **kwargs):
-        kwargs.setdefault("c", 1.0)
+        kwargs.setdefault("c", 3000.0)
         super().__init__(**kwargs)
-        self.initialize(amplitude=1.0)
 
 
-class SecondaryWave(WaveSimulation):
+class SecondaryWave(SWaveSimulation):
     """Shear body wave."""
 
     def __init__(self, **kwargs):
-        kwargs.setdefault("c", 0.6)
+        kwargs.setdefault("c", 1500.0)
         super().__init__(**kwargs)
-        self.initialize(amplitude=1.0)
 
 
-class SHWave(WaveSimulation):
+class SHWave(SHWaveSimulation):
     """Horizontally polarised shear."""
 
     def __init__(self, **kwargs):
-        kwargs.setdefault("c", 0.55)
+        kwargs.setdefault("c", 1500.0)
         super().__init__(**kwargs)
-        self.initialize(amplitude=1.0)
 
 
-class SVWave(WaveSimulation):
+class SVWave(SVWaveSimulation):
     """Vertically polarised shear."""
 
     def __init__(self, **kwargs):
-        kwargs.setdefault("c", 0.55)
+        kwargs.setdefault("c", 1500.0)
         super().__init__(**kwargs)
-        self.initialize(amplitude=1.0)
 
 
 ###############################################################################


### PR DESCRIPTION
## Summary
- implement time tracking in `WaveSimulation`
- implement `PWaveSimulation`, `SWaveSimulation`, `SHWaveSimulation` and `SVWaveSimulation`
- expose new classes in package and catalog
- update catalog classes to use the new simulations

## Testing
- `python - <<'PY'
from wave_sim import PWaveSimulation
sim=PWaveSimulation();
print(sim.step().shape)
PY` *(fails: ModuleNotFoundError: No module named 'numpy')*