### PR TITLE
Add example solvers for multiple wave types

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,15 @@ The solver emits a warning if the CFL condition ``c * dt / dx`` exceeds
 Animations can be generated via ``examples/all_waves_collage.py`` which iterates
 over every class in the catalog and writes a short MP4 file for each one into an
 ``output`` directory.
+
+
+Additional standalone scripts in the ``examples`` directory demonstrate simple
+1‑D or spectral solvers for several textbook waves:
+
+* ``internal_gravity_wave.py`` – finite difference scheme for a stratified fluid.
+* ``kelvin_wave.py`` – rotating shallow water Kelvin wave.
+* ``rossby_planetary_wave.py`` – linear Rossby wave via FFTs.
+* ``flexural_beam_wave.py`` – Euler–Bernoulli beam equation.
+* ``alfven_wave.py`` – 1‑D Alfv\u00e9n wave along a magnetic field.
+
+Each script runs a short simulation and plots the final state when executed.

--- a/examples/alfven_wave.py
+++ b/examples/alfven_wave.py
@@ -1,0 +1,46 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Alfv\u00e9n Wave Solver
+# ---------------------
+# Solves v_tt = v_A^2 v_xx along a uniform magnetic field.
+
+Lx = 2.0
+Nx = 200
+
+B0 = 1.0
+rho = 1.0
+mu0 = 1.0
+
+vA = B0 / np.sqrt(mu0 * rho)
+
+dx = Lx / (Nx - 1)
+Tmax = 2.0
+dt = 0.8 * dx / vA
+nt = int(Tmax / dt)
+
+x = np.linspace(0, Lx, Nx)
+
+v_old = np.sin(2 * np.pi * x / Lx)
+v = v_old.copy()
+v_new = np.zeros_like(v)
+
+for _ in range(nt):
+    for i in range(1, Nx - 1):
+        v_new[i] = (
+            2 * v[i]
+            - v_old[i]
+            + (vA * dt / dx) ** 2 * (v[i + 1] - 2 * v[i] + v[i - 1])
+        )
+    v_new[0] = 0.0
+    v_new[-1] = 0.0
+    v_old, v = v, v_new
+
+plt.figure(figsize=(8, 4))
+plt.plot(x, v, label="v_perp at final time")
+plt.xlabel("x")
+plt.ylabel("Transverse velocity")
+plt.title("Alfv\u00e9n Wave - Final State")
+plt.grid(True)
+plt.legend()
+plt.show()

--- a/examples/flexural_beam_wave.py
+++ b/examples/flexural_beam_wave.py
@@ -1,0 +1,47 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Flexural Beam Wave Solver (Euler-Bernoulli)
+# ------------------------------------------
+# Solves w_tt + D w_xxxx = 0 for a thin beam using a
+# simple explicit finite difference scheme.
+
+Lx = 2.0
+Nx = 201
+
+D = 0.01
+
+x = np.linspace(0, Lx, Nx)
+dx = x[1] - x[0]
+
+cfl = 0.2
+dt = cfl * dx ** 2 / np.sqrt(D)
+Tmax = 5.0
+nt = int(Tmax / dt)
+
+w_old = np.zeros(Nx)
+w = np.exp(-100 * (x - Lx / 2) ** 2)
+w_old[:] = w
+w_new = np.zeros_like(w)
+
+for _ in range(nt):
+    for i in range(2, Nx - 2):
+        w_xx = (w[i + 1] - 2 * w[i] + w[i - 1]) / dx ** 2
+        w_xx_plus = (w[i + 2] - 2 * w[i + 1] + w[i]) / dx ** 2
+        w_xx_minus = (w[i] - 2 * w[i - 1] + w[i - 2]) / dx ** 2
+        w_xxxx = (w_xx_plus - 2 * w_xx + w_xx_minus) / dx ** 2
+        w_new[i] = 2 * w[i] - w_old[i] + dt ** 2 * (-D * w_xxxx)
+    w_new[0] = 0.0
+    w_new[1] = 0.0
+    w_new[-1] = 0.0
+    w_new[-2] = 0.0
+    w_old, w = w, w_new
+
+plt.figure(figsize=(8, 4))
+plt.plot(x, w, label="w at final time")
+plt.xlabel("x")
+plt.ylabel("Displacement")
+plt.title("Flexural Beam Wave - Final")
+plt.grid(True)
+plt.legend()
+plt.show()

--- a/examples/internal_gravity_wave.py
+++ b/examples/internal_gravity_wave.py
@@ -1,0 +1,45 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Internal Gravity Wave Solver
+# ----------------------------
+# Solves psi_tt = N^2 psi_xx on a 1-D grid using a simple
+# finite difference scheme with Dirichlet boundaries.
+
+Lx = 2.0
+Nx = 200
+Nfreq = 1.0
+
+c = Nfreq
+
+dx = Lx / (Nx - 1)
+Tmax = 3.0
+dt = 0.8 * dx / c
+nt = int(Tmax / dt)
+
+x = np.linspace(0, Lx, Nx)
+
+psi_old = np.zeros(Nx)
+psi = np.exp(-100 * (x - Lx / 2) ** 2)
+psi_old[:] = psi
+psi_new = np.zeros_like(psi)
+
+for _ in range(nt):
+    for i in range(1, Nx - 1):
+        psi_new[i] = (
+            2 * psi[i]
+            - psi_old[i]
+            + (c * dt / dx) ** 2 * (psi[i + 1] - 2 * psi[i] + psi[i - 1])
+        )
+    psi_new[0] = 0.0
+    psi_new[-1] = 0.0
+    psi_old, psi = psi, psi_new
+
+plt.figure(figsize=(8, 4))
+plt.plot(x, psi, label="psi at final time")
+plt.xlabel("x")
+plt.ylabel("psi")
+plt.title("Internal Gravity Wave - Final State")
+plt.grid(True)
+plt.legend()
+plt.show()

--- a/examples/kelvin_wave.py
+++ b/examples/kelvin_wave.py
@@ -1,0 +1,59 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Kelvin Wave Solver (1-D along y with rotation)
+# ---------------------------------------------
+# Simple explicit finite difference scheme for the rotating shallow water
+# equations demonstrating a boundary trapped Kelvin wave.
+
+Ly = 10.0
+Ny = 200
+
+dy = Ly / (Ny - 1)
+
+H = 1.0
+f = 1.0
+g = 9.81
+
+c = np.sqrt(g * H)
+Tmax = 10.0
+dt = 0.4 * dy / c
+nt = int(Tmax / dt)
+
+y = np.linspace(0, Ly, Ny)
+
+u = np.zeros(Ny)
+v = np.zeros(Ny)
+eta = np.exp(-((y - Ly / 4) / 0.5) ** 2)
+
+u_new = np.zeros_like(u)
+v_new = np.zeros_like(v)
+eta_new = np.zeros_like(eta)
+
+for _ in range(nt):
+    for j in range(1, Ny - 1):
+        du = -g * (eta[j + 1] - eta[j - 1]) / (2 * dy) + f * v[j]
+        dv = -f * u[j]
+        deta = -H * (u[j + 1] - u[j - 1]) / (2 * dy)
+        u_new[j] = u[j] + dt * du
+        v_new[j] = v[j] + dt * dv
+        eta_new[j] = eta[j] + dt * deta
+
+    u_new[0] = 0.0
+    v_new[0] = 0.0
+    eta_new[0] = eta[0]
+
+    u_new[-1] = u[-1]
+    v_new[-1] = v[-1]
+    eta_new[-1] = eta[-1]
+
+    u, v, eta = u_new.copy(), v_new.copy(), eta_new.copy()
+
+plt.figure(figsize=(8, 4))
+plt.plot(y, eta, label="eta at final time")
+plt.xlabel("y")
+plt.ylabel("Surface perturbation")
+plt.title("Kelvin Wave - Final Surface Perturbation")
+plt.grid(True)
+plt.legend()
+plt.show()

--- a/examples/rossby_planetary_wave.py
+++ b/examples/rossby_planetary_wave.py
@@ -1,0 +1,48 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Rossby Planetary Wave Solver using a simple spectral method.
+# -----------------------------------------------------------
+# Integrates zeta_t + beta * psi_x = 0 with zeta = nabla^2 psi on a 2-D
+# periodic domain using FFTs.
+
+Nx = 64
+Ny = 64
+Lx = 2.0 * np.pi
+Ly = 2.0 * np.pi
+
+dx = Lx / Nx
+dy = Ly / Ny
+
+beta = 1.0
+dt = 0.01
+nt = 300
+
+kx = np.fft.fftfreq(Nx, d=dx) * 2 * np.pi
+ky = np.fft.fftfreq(Ny, d=dy) * 2 * np.pi
+kx2D, ky2D = np.meshgrid(kx, ky, indexing="ij")
+k2 = kx2D ** 2 + ky2D ** 2
+k2[0, 0] = 1e-14
+
+x = np.linspace(0, Lx, Nx, endpoint=False)
+y = np.linspace(0, Ly, Ny, endpoint=False)
+X, Y = np.meshgrid(x, y, indexing="ij")
+
+psi0 = np.exp(-((X - Lx / 2) ** 2 + (Y - Ly / 2) ** 2) / 0.2)
+psi_hat = np.fft.fftn(psi0)
+zeta_hat = -k2 * psi_hat
+
+for _ in range(nt):
+    psi_x_hat = 1j * kx2D * psi_hat
+    zeta_hat = zeta_hat + dt * (-beta * psi_x_hat)
+    psi_hat = -zeta_hat / k2
+
+psi_final = np.fft.ifftn(psi_hat).real
+
+plt.figure(figsize=(6, 5))
+plt.contourf(X, Y, psi_final, levels=20, cmap="RdBu_r")
+plt.colorbar(label="Streamfunction")
+plt.xlabel("x")
+plt.ylabel("y")
+plt.title("Rossby Planetary Wave - Final \u03c8")
+plt.show()


### PR DESCRIPTION
## Summary
- add implementations for Internal Gravity, Kelvin, Rossby Planetary, Flexural Beam, and Alfvén waves
- document the new example scripts

## Testing
- `python -m py_compile examples/alfven_wave.py examples/flexural_beam_wave.py examples/internal_gravity_wave.py examples/kelvin_wave.py examples/rossby_planetary_wave.py`