### PR TITLE
Organize solvers and refresh examples

### DIFF
--- a/examples/alfven_wave.py
+++ b/examples/alfven_wave.py
@@ -1,46 +1,26 @@
-import numpy as np
+"""Alfv\u00e9n wave example using the consolidated solver."""
+
 import matplotlib.pyplot as plt
+import numpy as np
 
-# Alfv\u00e9n Wave Solver
-# ---------------------
-# Solves v_tt = v_A^2 v_xx along a uniform magnetic field.
+from wave_sim import AlfvenWave
 
-Lx = 2.0
-Nx = 400
 
-B0 = 1.0
-rho = 1.0
-mu0 = 1.0
+def v0(x):
+    L = x[-1]
+    return np.sin(2 * np.pi * x / L)
 
-vA = B0 / np.sqrt(mu0 * rho)
 
-dx = Lx / (Nx - 1)
-Tmax = 2.0
-dt = 0.8 * dx / vA
-nt = int(Tmax / dt)
+if __name__ == "__main__":
+    sim = AlfvenWave(L=2.0, Nx=800, T=2.0)
+    sim.initial_conditions(v0)
+    sol = sim.solve()
+    plt.figure(figsize=(8, 4))
+    plt.plot(sim.x, sol[-1], label="v_perp at final time")
+    plt.xlabel("x")
+    plt.ylabel("Transverse velocity")
+    plt.title("Alfv\u00e9n Wave - Final State")
+    plt.grid(True)
+    plt.legend()
+    plt.show()
 
-x = np.linspace(0, Lx, Nx)
-
-v_old = np.sin(2 * np.pi * x / Lx)
-v = v_old.copy()
-v_new = np.zeros_like(v)
-
-for _ in range(nt):
-    for i in range(1, Nx - 1):
-        v_new[i] = (
-            2 * v[i]
-            - v_old[i]
-            + (vA * dt / dx) ** 2 * (v[i + 1] - 2 * v[i] + v[i - 1])
-        )
-    v_new[0] = 0.0
-    v_new[-1] = 0.0
-    v_old, v = v, v_new
-
-plt.figure(figsize=(8, 4))
-plt.plot(x, v, label="v_perp at final time")
-plt.xlabel("x")
-plt.ylabel("Transverse velocity")
-plt.title("Alfv\u00e9n Wave - Final State")
-plt.grid(True)
-plt.legend()
-plt.show()

--- a/examples/all_waves_collage.py
+++ b/examples/all_waves_collage.py
@@ -79,9 +79,9 @@ def main():
     for wave_cls in wave_classes:
         name = wave_cls.__name__
         print(f"Running {name}...")
-        sim = wave_cls(grid_size=300, boundary="absorbing", source_func=gaussian_source)
+        sim = wave_cls(grid_size=512, boundary="absorbing", source_func=gaussian_source)
         outfile = os.path.join("output", name.lower())
-        files.append(run_and_save(sim, outfile, steps=150))
+        files.append(run_and_save(sim, outfile, steps=300))
 
     print("Generated files:")
     for path in files:

--- a/examples/body_wave_fd.py
+++ b/examples/body_wave_fd.py
@@ -1,128 +1,30 @@
-# Simple 2-D finite-difference simulations for P, S, SH and SV waves
-# These snippets replicate the examples from the project documentation.
+"""High-resolution finite-difference body wave examples using ``wave_sim``."""
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+
+from wave_sim import PWaveSimulation, SWaveSimulation, SHWaveSimulation, SVWaveSimulation
 
 
-def ricker_wavelet(t, f0):
-    """Return a Ricker wavelet with dominant frequency ``f0`` at time ``t``."""
-    tau = 1.0 / f0
-    arg = np.pi * f0 * (t - tau)
-    return (1.0 - 2.0 * arg**2) * np.exp(-arg**2)
+def gaussian(X, Y, sigma=5.0):
+    cx = X.shape[0] // 2
+    cy = Y.shape[1] // 2
+    return np.exp(-((X - cx) ** 2 + (Y - cy) ** 2) / (2 * sigma ** 2))
 
 
-# ---------------------------------------------------------------------------
-# P-WAVE SIMULATION
-# ---------------------------------------------------------------------------
-
-def simulate_p_wave(nx=400, nz=400, dx=5.0, dz=5.0, alpha=3000.0, dt=0.0005, nt=750, f0=15.0):
-    P_now = np.zeros((nx, nz))
-    P_prev = np.zeros((nx, nz))
-    P_next = np.zeros((nx, nz))
-    sx, sz = nx // 2, nz // 2
-
-    snapshots = []
-    for it in range(nt):
-        for i in range(1, nx - 1):
-            for j in range(1, nz - 1):
-                lap = (
-                    (P_now[i + 1, j] - 2.0 * P_now[i, j] + P_now[i - 1, j]) / dx**2
-                    + (P_now[i, j + 1] - 2.0 * P_now[i, j] + P_now[i, j - 1]) / dz**2
-                )
-                P_next[i, j] = 2.0 * P_now[i, j] - P_prev[i, j] + alpha**2 * dt**2 * lap
-
-        P_next[sx, sz] += ricker_wavelet(it * dt, f0)
-        P_prev, P_now, P_next = P_now, P_next, P_prev
-        if it % 50 == 0:
-            snapshots.append(P_now.copy())
-    return snapshots, P_now
-
-
-# ---------------------------------------------------------------------------
-# S-WAVE SIMULATION (scalar potential)
-# ---------------------------------------------------------------------------
-
-def simulate_s_wave(nx=400, nz=400, dx=5.0, dz=5.0, beta=1500.0, dt=0.0005, nt=750, f0=15.0):
-    S_now = np.zeros((nx, nz))
-    S_prev = np.zeros((nx, nz))
-    S_next = np.zeros((nx, nz))
-    sx, sz = nx // 2, nz // 2
-
-    snapshots = []
-    for it in range(nt):
-        for i in range(1, nx - 1):
-            for j in range(1, nz - 1):
-                lap = (
-                    (S_now[i + 1, j] - 2.0 * S_now[i, j] + S_now[i - 1, j]) / dx**2
-                    + (S_now[i, j + 1] - 2.0 * S_now[i, j] + S_now[i, j - 1]) / dz**2
-                )
-                S_next[i, j] = 2.0 * S_now[i, j] - S_prev[i, j] + beta**2 * dt**2 * lap
-
-        S_next[sx, sz] += ricker_wavelet(it * dt, f0)
-        S_prev, S_now, S_next = S_now, S_next, S_prev
-        if it % 50 == 0:
-            snapshots.append(S_now.copy())
-    return snapshots, S_now
-
-
-# ---------------------------------------------------------------------------
-# SH-WAVE SIMULATION
-# ---------------------------------------------------------------------------
-
-def simulate_sh_wave(nx=400, nz=400, dx=5.0, dz=5.0, beta=1500.0, dt=0.0005, nt=750, f0=15.0):
-    uY_now = np.zeros((nx, nz))
-    uY_prev = np.zeros((nx, nz))
-    uY_next = np.zeros((nx, nz))
-    sx, sz = nx // 2, nz // 2
-
-    snapshots = []
-    for it in range(nt):
-        for i in range(1, nx - 1):
-            for j in range(1, nz - 1):
-                lap = (
-                    (uY_now[i + 1, j] - 2.0 * uY_now[i, j] + uY_now[i - 1, j]) / dx**2
-                    + (uY_now[i, j + 1] - 2.0 * uY_now[i, j] + uY_now[i, j - 1]) / dz**2
-                )
-                uY_next[i, j] = 2.0 * uY_now[i, j] - uY_prev[i, j] + beta**2 * dt**2 * lap
-
-        uY_next[sx, sz] += ricker_wavelet(it * dt, f0)
-        uY_prev, uY_now, uY_next = uY_now, uY_next, uY_prev
-        if it % 50 == 0:
-            snapshots.append(uY_now.copy())
-    return snapshots, uY_now
-
-
-# ---------------------------------------------------------------------------
-# SV-WAVE SIMULATION (scalar potential)
-# ---------------------------------------------------------------------------
-
-def simulate_sv_wave(nx=400, nz=400, dx=5.0, dz=5.0, beta=1500.0, dt=0.0005, nt=750, f0=15.0):
-    Psi_now = np.zeros((nx, nz))
-    Psi_prev = np.zeros((nx, nz))
-    Psi_next = np.zeros((nx, nz))
-    sx, sz = nx // 2, nz // 2
-
-    snapshots = []
-    for it in range(nt):
-        for i in range(1, nx - 1):
-            for j in range(1, nz - 1):
-                lap = (
-                    (Psi_now[i + 1, j] - 2.0 * Psi_now[i, j] + Psi_now[i - 1, j]) / dx**2
-                    + (Psi_now[i, j + 1] - 2.0 * Psi_now[i, j] + Psi_now[i, j - 1]) / dz**2
-                )
-                Psi_next[i, j] = 2.0 * Psi_now[i, j] - Psi_prev[i, j] + beta**2 * dt**2 * lap
-
-        Psi_next[sx, sz] += ricker_wavelet(it * dt, f0)
-        Psi_prev, Psi_now, Psi_next = Psi_now, Psi_next, Psi_prev
-        if it % 50 == 0:
-            snapshots.append(Psi_now.copy())
-    return snapshots, Psi_now
+def run(sim_cls, title):
+    sim = sim_cls(grid_size=512, boundary="absorbing", source_func=gaussian)
+    frames = sim.simulate(steps=750)
+    plt.figure()
+    plt.imshow(frames[-1], cmap="seismic", origin="lower", aspect="auto")
+    plt.title(title)
+    plt.colorbar(label="Amplitude")
 
 
 if __name__ == "__main__":
-    snaps, field = simulate_p_wave(nt=400)
-    plt.imshow(field.T, cmap="seismic", origin="lower", aspect="auto")
-    plt.title("Final P-Wave Field")
-    plt.colorbar(label="Amplitude")
+    run(PWaveSimulation, "P-Wave")
+    run(SWaveSimulation, "S-Wave")
+    run(SHWaveSimulation, "SH-Wave")
+    run(SVWaveSimulation, "SV-Wave")
     plt.show()
+

--- a/examples/flexural_beam_wave.py
+++ b/examples/flexural_beam_wave.py
@@ -1,47 +1,26 @@
-import numpy as np
+"""Flexural beam wave solved with the consolidated solver."""
+
 import matplotlib.pyplot as plt
+import numpy as np
 
-# Flexural Beam Wave Solver (Euler-Bernoulli)
-# ------------------------------------------
-# Solves w_tt + D w_xxxx = 0 for a thin beam using a
-# simple explicit finite difference scheme.
+from wave_sim import FlexuralBeamWave
 
-Lx = 2.0
-Nx = 401
 
-D = 0.01
+def w0(x):
+    L = x[-1]
+    return np.exp(-100 * (x - L / 2) ** 2)
 
-x = np.linspace(0, Lx, Nx)
-dx = x[1] - x[0]
 
-cfl = 0.2
-dt = cfl * dx ** 2 / np.sqrt(D)
-Tmax = 5.0
-nt = int(Tmax / dt)
+if __name__ == "__main__":
+    sim = FlexuralBeamWave(L=2.0, Nx=801, T=5.0)
+    sim.initial_conditions(w0)
+    sol = sim.solve()
+    plt.figure(figsize=(8, 4))
+    plt.plot(sim.x, sol[-1], label="w at final time")
+    plt.xlabel("x")
+    plt.ylabel("Displacement")
+    plt.title("Flexural Beam Wave - Final")
+    plt.grid(True)
+    plt.legend()
+    plt.show()
 
-w_old = np.zeros(Nx)
-w = np.exp(-100 * (x - Lx / 2) ** 2)
-w_old[:] = w
-w_new = np.zeros_like(w)
-
-for _ in range(nt):
-    for i in range(2, Nx - 2):
-        w_xx = (w[i + 1] - 2 * w[i] + w[i - 1]) / dx ** 2
-        w_xx_plus = (w[i + 2] - 2 * w[i + 1] + w[i]) / dx ** 2
-        w_xx_minus = (w[i] - 2 * w[i - 1] + w[i - 2]) / dx ** 2
-        w_xxxx = (w_xx_plus - 2 * w_xx + w_xx_minus) / dx ** 2
-        w_new[i] = 2 * w[i] - w_old[i] + dt ** 2 * (-D * w_xxxx)
-    w_new[0] = 0.0
-    w_new[1] = 0.0
-    w_new[-1] = 0.0
-    w_new[-2] = 0.0
-    w_old, w = w, w_new
-
-plt.figure(figsize=(8, 4))
-plt.plot(x, w, label="w at final time")
-plt.xlabel("x")
-plt.ylabel("Displacement")
-plt.title("Flexural Beam Wave - Final")
-plt.grid(True)
-plt.legend()
-plt.show()

--- a/examples/internal_gravity_wave.py
+++ b/examples/internal_gravity_wave.py
@@ -1,45 +1,26 @@
-import numpy as np
+"""1-D internal gravity wave using the consolidated solver."""
+
 import matplotlib.pyplot as plt
+import numpy as np
 
-# Internal Gravity Wave Solver
-# ----------------------------
-# Solves psi_tt = N^2 psi_xx on a 1-D grid using a simple
-# finite difference scheme with Dirichlet boundaries.
+from wave_sim import InternalGravityWave
 
-Lx = 2.0
-Nx = 400
-Nfreq = 1.0
 
-c = Nfreq
+def psi0(x):
+    return np.exp(-100 * (x - 1.0) ** 2)
 
-dx = Lx / (Nx - 1)
-Tmax = 3.0
-dt = 0.8 * dx / c
-nt = int(Tmax / dt)
 
-x = np.linspace(0, Lx, Nx)
+if __name__ == "__main__":
+    sim = InternalGravityWave(L=2.0, Nx=800, T=3.0)
+    sim.initial_conditions(psi0)
+    sol = sim.solve()
+    x = sim.x
+    plt.figure(figsize=(8, 4))
+    plt.plot(x, sol[-1], label="psi at final time")
+    plt.xlabel("x")
+    plt.ylabel("psi")
+    plt.title("Internal Gravity Wave - Final State")
+    plt.grid(True)
+    plt.legend()
+    plt.show()
 
-psi_old = np.zeros(Nx)
-psi = np.exp(-100 * (x - Lx / 2) ** 2)
-psi_old[:] = psi
-psi_new = np.zeros_like(psi)
-
-for _ in range(nt):
-    for i in range(1, Nx - 1):
-        psi_new[i] = (
-            2 * psi[i]
-            - psi_old[i]
-            + (c * dt / dx) ** 2 * (psi[i + 1] - 2 * psi[i] + psi[i - 1])
-        )
-    psi_new[0] = 0.0
-    psi_new[-1] = 0.0
-    psi_old, psi = psi, psi_new
-
-plt.figure(figsize=(8, 4))
-plt.plot(x, psi, label="psi at final time")
-plt.xlabel("x")
-plt.ylabel("psi")
-plt.title("Internal Gravity Wave - Final State")
-plt.grid(True)
-plt.legend()
-plt.show()

--- a/examples/kelvin_wave.py
+++ b/examples/kelvin_wave.py
@@ -1,59 +1,26 @@
-import numpy as np
+"""Rotating shallow water Kelvin wave using the unified solver."""
+
 import matplotlib.pyplot as plt
+import numpy as np
 
-# Kelvin Wave Solver (1-D along y with rotation)
-# ---------------------------------------------
-# Simple explicit finite difference scheme for the rotating shallow water
-# equations demonstrating a boundary trapped Kelvin wave.
+from wave_sim import KelvinWave
 
-Ly = 10.0
-Ny = 400
 
-dy = Ly / (Ny - 1)
+def eta0(y):
+    return np.exp(-((y - 2.5) / 0.5) ** 2)
 
-H = 1.0
-f = 1.0
-g = 9.81
 
-c = np.sqrt(g * H)
-Tmax = 10.0
-dt = 0.4 * dy / c
-nt = int(Tmax / dt)
+if __name__ == "__main__":
+    sim = KelvinWave(L=10.0, Ny=800, T=10.0)
+    sim.initial_conditions(eta0)
+    sol = sim.solve()
+    y = sim.y
+    plt.figure(figsize=(8, 4))
+    plt.plot(y, sol[-1], label="eta at final time")
+    plt.xlabel("y")
+    plt.ylabel("Surface perturbation")
+    plt.title("Kelvin Wave - Final Surface Perturbation")
+    plt.grid(True)
+    plt.legend()
+    plt.show()
 
-y = np.linspace(0, Ly, Ny)
-
-u = np.zeros(Ny)
-v = np.zeros(Ny)
-eta = np.exp(-((y - Ly / 4) / 0.5) ** 2)
-
-u_new = np.zeros_like(u)
-v_new = np.zeros_like(v)
-eta_new = np.zeros_like(eta)
-
-for _ in range(nt):
-    for j in range(1, Ny - 1):
-        du = -g * (eta[j + 1] - eta[j - 1]) / (2 * dy) + f * v[j]
-        dv = -f * u[j]
-        deta = -H * (u[j + 1] - u[j - 1]) / (2 * dy)
-        u_new[j] = u[j] + dt * du
-        v_new[j] = v[j] + dt * dv
-        eta_new[j] = eta[j] + dt * deta
-
-    u_new[0] = 0.0
-    v_new[0] = 0.0
-    eta_new[0] = eta[0]
-
-    u_new[-1] = u[-1]
-    v_new[-1] = v[-1]
-    eta_new[-1] = eta[-1]
-
-    u, v, eta = u_new.copy(), v_new.copy(), eta_new.copy()
-
-plt.figure(figsize=(8, 4))
-plt.plot(y, eta, label="eta at final time")
-plt.xlabel("y")
-plt.ylabel("Surface perturbation")
-plt.title("Kelvin Wave - Final Surface Perturbation")
-plt.grid(True)
-plt.legend()
-plt.show()

--- a/examples/rossby_planetary_wave.py
+++ b/examples/rossby_planetary_wave.py
@@ -1,48 +1,31 @@
-import numpy as np
+"""Linear Rossby planetary wave solved spectrally."""
+
 import matplotlib.pyplot as plt
+import numpy as np
 
-# Rossby Planetary Wave Solver using a simple spectral method.
-# -----------------------------------------------------------
-# Integrates zeta_t + beta * psi_x = 0 with zeta = nabla^2 psi on a 2-D
-# periodic domain using FFTs.
+from wave_sim import RossbyPlanetaryWave
 
-Nx = 128
-Ny = 128
-Lx = 2.0 * np.pi
-Ly = 2.0 * np.pi
 
-dx = Lx / Nx
-dy = Ly / Ny
+def psi0(X, Y):
+    Lx = X.max()
+    Ly = Y.max()
+    return np.exp(-((X - Lx / 2) ** 2 + (Y - Ly / 2) ** 2) / 0.2)
 
-beta = 1.0
-dt = 0.01
-nt = 300
 
-kx = np.fft.fftfreq(Nx, d=dx) * 2 * np.pi
-ky = np.fft.fftfreq(Ny, d=dy) * 2 * np.pi
-kx2D, ky2D = np.meshgrid(kx, ky, indexing="ij")
-k2 = kx2D ** 2 + ky2D ** 2
-k2[0, 0] = 1e-14
+if __name__ == "__main__":
+    sim = RossbyPlanetaryWave(Nx=256, Ny=256, T=3.0)
+    sim.initial_conditions(psi0)
+    sol = sim.solve()
+    X, Y = np.meshgrid(
+        np.linspace(0, sim.Lx, sim.Nx, endpoint=False),
+        np.linspace(0, sim.Ly, sim.Ny, endpoint=False),
+        indexing="ij",
+    )
+    plt.figure(figsize=(6, 5))
+    plt.contourf(X, Y, sol[-1], levels=20, cmap="RdBu_r")
+    plt.colorbar(label="Streamfunction")
+    plt.xlabel("x")
+    plt.ylabel("y")
+    plt.title("Rossby Planetary Wave - Final \u03c8")
+    plt.show()
 
-x = np.linspace(0, Lx, Nx, endpoint=False)
-y = np.linspace(0, Ly, Ny, endpoint=False)
-X, Y = np.meshgrid(x, y, indexing="ij")
-
-psi0 = np.exp(-((X - Lx / 2) ** 2 + (Y - Ly / 2) ** 2) / 0.2)
-psi_hat = np.fft.fftn(psi0)
-zeta_hat = -k2 * psi_hat
-
-for _ in range(nt):
-    psi_x_hat = 1j * kx2D * psi_hat
-    zeta_hat = zeta_hat + dt * (-beta * psi_x_hat)
-    psi_hat = -zeta_hat / k2
-
-psi_final = np.fft.ifftn(psi_hat).real
-
-plt.figure(figsize=(6, 5))
-plt.contourf(X, Y, psi_final, levels=20, cmap="RdBu_r")
-plt.colorbar(label="Streamfunction")
-plt.xlabel("x")
-plt.ylabel("y")
-plt.title("Rossby Planetary Wave - Final \u03c8")
-plt.show()

--- a/wave_sim/wave_catalog.py
+++ b/wave_sim/wave_catalog.py
@@ -6,6 +6,7 @@ phenomena.  Each class simply sets a default wave speed ``c`` and initialises
 the field with a unit impulse in the centre of the grid.
 """
 
+import numpy as np
 from .base import WaveSimulation
 from .solvers import (
     PWaveSimulation,
@@ -17,6 +18,11 @@ from .solvers import (
     DeepWaterGravityWave,
     ShallowWaterGravityWave,
     CapillaryWave,
+    InternalGravityWave as InternalGravityWaveSolver,
+    KelvinWave as KelvinWaveSolver,
+    RossbyPlanetaryWave as RossbyPlanetaryWaveSolver,
+    FlexuralBeamWave as FlexuralBeamWaveSolver,
+    AlfvenWave as AlfvenWaveSolver,
 )
 
 
@@ -122,53 +128,48 @@ class ScholteWave(WaveSimulation):
 # FLUID SURFACE AND INTERNAL WAVES
 ###############################################################################
 
-class InternalGravityWave(WaveSimulation):
+class InternalGravityWave(InternalGravityWaveSolver):
     """Internal gravity wave."""
 
     def __init__(self, **kwargs):
-        kwargs.setdefault("c", 0.2)
         super().__init__(**kwargs)
-        self.initialize(amplitude=1.0)
+        self.initial_conditions(lambda x: np.exp(-100 * (x - self.L / 2) ** 2))
 
 
-class KelvinWave(WaveSimulation):
+class KelvinWave(KelvinWaveSolver):
     """Kelvin wave."""
 
     def __init__(self, **kwargs):
-        kwargs.setdefault("c", 0.2)
         super().__init__(**kwargs)
-        self.initialize(amplitude=1.0)
+        self.initial_conditions(lambda y: np.exp(-((y - self.L / 4) / 0.5) ** 2))
 
 
-class RossbyPlanetaryWave(WaveSimulation):
+class RossbyPlanetaryWave(RossbyPlanetaryWaveSolver):
     """Rossby planetary wave."""
 
     def __init__(self, **kwargs):
-        kwargs.setdefault("c", 0.05)
         super().__init__(**kwargs)
-        self.initialize(amplitude=1.0)
+        self.initial_conditions(lambda X, Y: np.exp(-((X - self.Lx / 2) ** 2 + (Y - self.Ly / 2) ** 2) / 0.2))
 
 
 ###############################################################################
 # STRUCTURAL AND PLASMA WAVES
 ###############################################################################
 
-class FlexuralBeamWave(WaveSimulation):
+class FlexuralBeamWave(FlexuralBeamWaveSolver):
     """Flexural beam wave."""
 
     def __init__(self, **kwargs):
-        kwargs.setdefault("c", 0.4)
         super().__init__(**kwargs)
-        self.initialize(amplitude=1.0)
+        self.initial_conditions(lambda x: np.exp(-100 * (x - self.L / 2) ** 2))
 
 
-class AlfvenWave(WaveSimulation):
+class AlfvenWave(AlfvenWaveSolver):
     """Alfv\u00e9n wave."""
 
     def __init__(self, **kwargs):
-        kwargs.setdefault("c", 1.0)
         super().__init__(**kwargs)
-        self.initialize(amplitude=1.0)
+        self.initial_conditions(lambda x: np.sin(2 * np.pi * x / self.L))
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- centralize additional wave solvers in `wave_sim/solvers.py`
- hook `wave_catalog` classes to the new solver implementations
- modernize example scripts to use the package and higher resolution grids
- bump resolution of `all_waves_collage.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
