### PR TITLE
Add dispersion wave solvers

### DIFF
--- a/wave_sim/__init__.py
+++ b/wave_sim/__init__.py
@@ -30,7 +30,7 @@ from .wave_catalog import (
     AlfvenWave,
 )
 
-from .dispersion import (
+from .solvers import (
     rayleigh_wave_speed,
     love_wave_dispersion,
     lamb_s0_mode,


### PR DESCRIPTION
## Summary
- include numerical wave-speed solvers in `solvers.py`
- export new solvers from module API
- pull dispersion utilities from `solvers` rather than `dispersion`

## Testing
- `python -m py_compile wave_sim/solvers.py wave_sim/__init__.py`
- `python -m py_compile wave_sim/dispersion.py`