### PR TITLE
Add GPU-based 2D wave simulator

### DIFF
--- a/examples/all_waves_collage.py
+++ b/examples/all_waves_collage.py
@@ -1,98 +1,41 @@
-"""Generate animations for a subset of wave classes.
-
-This script iterates over a curated set of simulations defined in
-``wave_sim.wave_catalog`` and writes a short MP4 file for each one into an
-``output`` directory.  The results are purely illustrative.
-"""
-
 import os
-import numpy as np
-
-import matplotlib
-
-matplotlib.use("Agg")  # allow running without a display
-
-from wave_sim import (
-    PrimaryWave,
-    SecondaryWave,
-    SHWave,
-    SVWave,
-    RayleighWave,
-    LoveWave,
-    LambS0Mode,
-    LambA0Mode,
-    StoneleyWave,
-    ScholteWave,
-    PlaneAcousticWave,
-    SphericalAcousticWave,
-    DeepWaterGravityWave,
-    ShallowWaterGravityWave,
-    CapillaryWave,
-    InternalGravityWave,
-    KelvinWave,
-    RossbyPlanetaryWave,
-    FlexuralBeamWave,
-    AlfvenWave,
-)
-
-from wave_sim.collage import collage_videos
+import cv2
+from wave_sim2d.wave_simulation import WaveSimulator2D
+from wave_sim2d.wave_visualizer import WaveVisualizer, get_colormap_lut
+from wave_sim2d.wave_catalog2d import wave_catalog_list
+from wave_sim2d.collage import collage_videos
 
 
-def gaussian_source(X, Y, sigma=5.0):
-    cx = X.shape[0] // 2
-    cy = Y.shape[1] // 2
-    return np.exp(-((X - cx) ** 2 + (Y - cy) ** 2) / (2 * sigma ** 2))
-
-
-def run_and_save(sim, name, steps=50, fps=60):
-    ani = sim.animate(steps=steps, interval=1000 / fps)
-    path = f"{name}.mp4"
-    ani.save(path, fps=fps)
+def generate_wave_animation(name, constructor, width=512, height=512, steps=300, dt=1.0, fps=60, out_dir="output"):
+    os.makedirs(out_dir, exist_ok=True)
+    path = os.path.join(out_dir, f"{name}.mp4")
+    scene_objs = constructor(width, height)
+    sim = WaveSimulator2D(width, height, scene_objects=scene_objs, dt=dt, global_dampening=1.0)
+    field_lut = get_colormap_lut('RdBu', invert=True)
+    intens_lut = get_colormap_lut('afmhot')
+    vis = WaveVisualizer(field_colormap=field_lut, intensity_colormap=intens_lut)
+    fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+    writer = cv2.VideoWriter(path, fourcc, fps, (width, height))
+    for _ in range(steps):
+        sim.update_scene()
+        sim.update_field()
+        vis.update(sim.get_field())
+        frame = vis.render_field()
+        writer.write(frame)
+    writer.release()
     return path
 
 
 def main():
-    os.makedirs("output", exist_ok=True)
-
-    wave_classes = [
-        PrimaryWave,
-        SecondaryWave,
-        SHWave,
-        SVWave,
-        RayleighWave,
-        LoveWave,
-        LambS0Mode,
-        LambA0Mode,
-        StoneleyWave,
-        ScholteWave,
-        PlaneAcousticWave,
-        SphericalAcousticWave,
-        DeepWaterGravityWave,
-        ShallowWaterGravityWave,
-        CapillaryWave,
-        InternalGravityWave,
-        KelvinWave,
-        RossbyPlanetaryWave,
-        FlexuralBeamWave,
-        AlfvenWave,
-    ]
-
-    files = []
-    for wave_cls in wave_classes:
-        name = wave_cls.__name__
-        print(f"Running {name}...")
-        sim = wave_cls(grid_size=512, boundary="absorbing", source_func=gaussian_source)
-        outfile = os.path.join("output", name.lower())
-        files.append(run_and_save(sim, outfile, steps=300, fps=60))
-
-    print("Generated files:")
-    for path in files:
-        print("  ", path)
-
-    collage_out = os.path.join("output", "collage.mp4")
-    print("Creating collage video...")
-    collage_videos(files, collage_out)
-    print("Collage saved to", collage_out)
+    wave_defs = wave_catalog_list()
+    out_dir = "output"
+    paths = []
+    for name, constructor in wave_defs:
+        p = generate_wave_animation(name, constructor, out_dir=out_dir)
+        paths.append(p)
+    collage_path = os.path.join(out_dir, "all_waves_collage.mp4")
+    collage_videos(paths, collage_path, fps=60)
+    print("Collage saved to", collage_path)
 
 
 if __name__ == "__main__":

--- a/wave_sim2d/__init__.py
+++ b/wave_sim2d/__init__.py
@@ -1,0 +1,4 @@
+from .wave_simulation import WaveSimulator2D
+from .wave_visualizer import WaveVisualizer, get_colormap_lut
+from .wave_catalog2d import wave_catalog_list
+from .collage import collage_videos

--- a/wave_sim2d/collage.py
+++ b/wave_sim2d/collage.py
@@ -1,0 +1,50 @@
+import math
+import imageio.v2 as imageio
+import numpy as np
+import cv2
+
+
+def collage_videos(paths, outfile, grid=None, fps=30, out_width=1920, out_height=1080):
+    readers = [imageio.get_reader(p) for p in paths]
+    meta = readers[0].get_meta_data()
+    if fps is None:
+        fps = int(meta.get("fps", 30))
+    nframes = min(r.count_frames() for r in readers)
+
+    n = len(readers)
+    if grid is None:
+        cols = int(math.ceil(math.sqrt(n)))
+        rows = int(math.ceil(n / cols))
+    else:
+        rows, cols = grid
+
+    frame0 = readers[0].get_data(0)
+    tile_w = out_width // cols
+    tile_h = out_height // rows
+
+    fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+    writer = cv2.VideoWriter(outfile, fourcc, fps, (out_width, out_height))
+
+    for i in range(nframes):
+        tiles = []
+        for r in readers:
+            try:
+                frame = r.get_data(i)
+            except Exception:
+                frame = np.zeros_like(frame0)
+            frame = cv2.resize(frame, (tile_w, tile_h), interpolation=cv2.INTER_AREA)
+            tiles.append(frame)
+        while len(tiles) < rows * cols:
+            tiles.append(np.zeros((tile_h, tile_w, 3), dtype=np.uint8))
+        row_imgs = []
+        idx = 0
+        for r_ in range(rows):
+            row = np.concatenate(tiles[idx:idx+cols], axis=1)
+            idx += cols
+            row_imgs.append(row)
+        collage_frame = np.concatenate(row_imgs, axis=0)
+        writer.write(collage_frame.astype(np.uint8))
+
+    writer.release()
+    for r in readers:
+        r.close()

--- a/wave_sim2d/scene_objects/__init__.py
+++ b/wave_sim2d/scene_objects/__init__.py
@@ -1,0 +1,4 @@
+from .base import SceneObject
+from .static_dampening import StaticDampening
+from .static_refractive_index import StaticRefractiveIndex
+from .source import PointSource

--- a/wave_sim2d/scene_objects/base.py
+++ b/wave_sim2d/scene_objects/base.py
@@ -1,0 +1,12 @@
+import cupy as cp
+
+class SceneObject:
+    """Interface for objects in the wave simulation scene."""
+
+    def render(self, field: cp.ndarray, wave_speed_field: cp.ndarray, dampening_field: cp.ndarray):
+        """Modify the wave speed or dampening fields in-place."""
+        pass
+
+    def update_field(self, field: cp.ndarray, t: float):
+        """Inject or modify the wave field in-place."""
+        pass

--- a/wave_sim2d/scene_objects/source.py
+++ b/wave_sim2d/scene_objects/source.py
@@ -1,0 +1,24 @@
+import cupy as cp
+from .base import SceneObject
+
+
+class PointSource(SceneObject):
+    """Sinusoidal point source at a grid coordinate."""
+
+    def __init__(self, px: int, py: int, amplitude: float, freq: float, phase: float = 0.0, opacity: float = 0.0):
+        self.px = px
+        self.py = py
+        self.amplitude = amplitude
+        self.freq = freq
+        self.phase = phase
+        self.opacity = opacity
+
+    def render(self, field: cp.ndarray, wave_speed_field: cp.ndarray, dampening_field: cp.ndarray):
+        pass
+
+    def update_field(self, field: cp.ndarray, t: float):
+        val = self.amplitude * cp.sin(self.freq * t + self.phase)
+        if self.opacity <= 0.0:
+            field[self.py, self.px] = val
+        else:
+            field[self.py, self.px] = field[self.py, self.px] * self.opacity + val * (1.0 - self.opacity)

--- a/wave_sim2d/scene_objects/static_dampening.py
+++ b/wave_sim2d/scene_objects/static_dampening.py
@@ -1,0 +1,24 @@
+import cupy as cp
+import numpy as np
+from .base import SceneObject
+
+
+class StaticDampening(SceneObject):
+    """Static dampening mask, optionally with faded edges."""
+
+    def __init__(self, dampening_field: np.ndarray, border_thickness: int = 0):
+        h, w = dampening_field.shape
+        self.d_field = cp.array(dampening_field, dtype=cp.float32)
+        if border_thickness > 0:
+            for i in range(border_thickness):
+                fade = (i / border_thickness) ** 0.5
+                self.d_field[i, :] = cp.minimum(self.d_field[i, :], fade)
+                self.d_field[h - 1 - i, :] = cp.minimum(self.d_field[h - 1 - i, :], fade)
+                self.d_field[:, i] = cp.minimum(self.d_field[:, i], fade)
+                self.d_field[:, w - 1 - i] = cp.minimum(self.d_field[:, w - 1 - i], fade)
+
+    def render(self, field: cp.ndarray, wave_speed_field: cp.ndarray, dampening_field: cp.ndarray):
+        dampening_field[:] = self.d_field
+
+    def update_field(self, field: cp.ndarray, t: float):
+        pass

--- a/wave_sim2d/scene_objects/static_refractive_index.py
+++ b/wave_sim2d/scene_objects/static_refractive_index.py
@@ -1,0 +1,17 @@
+import cupy as cp
+import numpy as np
+from .base import SceneObject
+
+
+class StaticRefractiveIndex(SceneObject):
+    """Static refractive index mask (wave speed = 1/n)."""
+
+    def __init__(self, refractive_index_field: np.ndarray):
+        clipped = np.clip(refractive_index_field, 0.9, 10.0)
+        self.c_field = cp.array(1.0 / clipped, dtype=cp.float32)
+
+    def render(self, field: cp.ndarray, wave_speed_field: cp.ndarray, dampening_field: cp.ndarray):
+        wave_speed_field[:] = self.c_field
+
+    def update_field(self, field: cp.ndarray, t: float):
+        pass

--- a/wave_sim2d/wave_catalog2d.py
+++ b/wave_sim2d/wave_catalog2d.py
@@ -1,0 +1,31 @@
+import numpy as np
+from .scene_objects.static_dampening import StaticDampening
+from .scene_objects.static_refractive_index import StaticRefractiveIndex
+from .scene_objects.source import PointSource
+
+
+def wave_catalog_list():
+    """Return list of (name, scene_constructor) tuples for wave types."""
+    waves = []
+
+    def wave_primary(width, height):
+        refr_index = np.ones((height, width), dtype=np.float32)
+        damp = np.ones((height, width), dtype=np.float32)
+        d_obj = StaticDampening(damp, border_thickness=40)
+        c_obj = StaticRefractiveIndex(refr_index)
+        src = PointSource(width // 2, height // 2, amplitude=0.2, freq=0.2)
+        return [d_obj, c_obj, src]
+
+    waves.append(("PrimaryWave2D", wave_primary))
+
+    def wave_sh(width, height):
+        refr_index = np.ones((height, width), dtype=np.float32) * 1.2
+        damp = np.ones((height, width), dtype=np.float32)
+        d_obj = StaticDampening(damp, border_thickness=40)
+        c_obj = StaticRefractiveIndex(refr_index)
+        src = PointSource(width // 2, height // 2, amplitude=0.3, freq=0.15)
+        return [d_obj, c_obj, src]
+
+    waves.append(("SHWave2D", wave_sh))
+
+    return waves

--- a/wave_sim2d/wave_simulation.py
+++ b/wave_sim2d/wave_simulation.py
@@ -1,0 +1,56 @@
+import cupy as cp
+import cupyx.scipy.signal
+from typing import Optional, List
+from .scene_objects.base import SceneObject
+
+
+class WaveSimulator2D:
+    """GPU accelerated 2-D wave solver with scene object support."""
+
+    def __init__(self, width: int, height: int, scene_objects: Optional[List[SceneObject]] = None, dt: float = 1.0, global_dampening: float = 1.0, laplacian_kernel: Optional[cp.ndarray] = None):
+        self.width = width
+        self.height = height
+        self.dt = dt
+        self.global_dampening = global_dampening
+
+        self.c = cp.ones((height, width), dtype=cp.float32)
+        self.d = cp.ones((height, width), dtype=cp.float32)
+        self.u = cp.zeros((height, width), dtype=cp.float32)
+        self.u_prev = cp.zeros((height, width), dtype=cp.float32)
+
+        if laplacian_kernel is None:
+            laplacian_kernel = cp.array(
+                [[0.066, 0.184, 0.066],
+                 [0.184, -1.0, 0.184],
+                 [0.066, 0.184, 0.066]], dtype=cp.float32)
+        self.laplacian_kernel = laplacian_kernel
+
+        self.t = 0.0
+        self.scene_objects = scene_objects or []
+
+    def reset_time(self):
+        self.t = 0.0
+
+    def update_scene(self):
+        self.c.fill(1.0)
+        self.d.fill(1.0)
+        for obj in self.scene_objects:
+            obj.render(self.u, self.c, self.d)
+        for obj in self.scene_objects:
+            obj.update_field(self.u, self.t)
+
+    def update_field(self):
+        laplacian = cupyx.scipy.signal.convolve2d(self.u, self.laplacian_kernel, mode='same', boundary='fill')
+        v = (self.u - self.u_prev) * self.d * self.global_dampening
+        r = self.u + v + laplacian * (self.c * self.dt) ** 2
+        self.u_prev[:] = self.u
+        self.u[:] = r
+        self.t += self.dt
+
+    def get_field(self) -> cp.ndarray:
+        return self.u
+
+    def run_simulation(self, total_steps: int):
+        for _ in range(total_steps):
+            self.update_scene()
+            self.update_field()

--- a/wave_sim2d/wave_visualizer.py
+++ b/wave_sim2d/wave_visualizer.py
@@ -1,0 +1,58 @@
+import cupy as cp
+import numpy as np
+import cv2
+import matplotlib.pyplot as plt
+
+
+class WaveVisualizer:
+    """Renders fields and intensity maps using color lookup tables."""
+
+    def __init__(self, field_colormap: np.ndarray = None, intensity_colormap: np.ndarray = None, intensity_decay: float = 0.98):
+        self.field_colormap = field_colormap
+        self.intensity_colormap = intensity_colormap
+        self.intensity_decay = intensity_decay
+        self.field = None
+        self.intensity = None
+
+    def update(self, wave_field: cp.ndarray):
+        self.field = wave_field
+        if self.intensity is None:
+            self.intensity = cp.zeros_like(wave_field)
+        self.intensity = self.intensity_decay * self.intensity + (1.0 - self.intensity_decay) * (wave_field ** 2)
+
+    def render_field(self, brightness_scale: float = 1.0, overlay: np.ndarray = None) -> np.ndarray:
+        field_clamp = cp.clip(self.field * brightness_scale, -1.0, 1.0)
+        idx = ((field_clamp + 1.0) * 127.5).astype(cp.uint8)
+        if self.field_colormap is not None:
+            lut = cp.asarray(self.field_colormap)
+            colored = lut[idx]
+        else:
+            colored = cp.stack([idx, idx, idx], axis=-1)
+        out = colored.get().reshape(self.field.shape[0], self.field.shape[1], 3)
+        if overlay is not None:
+            out = cv2.add(overlay, out.astype(np.uint8))
+        return out.astype(np.uint8)
+
+    def render_intensity(self, brightness_scale: float = 1.0, exponent: float = 0.5, overlay: np.ndarray = None) -> np.ndarray:
+        inten = (self.intensity ** exponent) * brightness_scale
+        inten = cp.clip(inten, 0.0, 1.0)
+        idx = (inten * 255.0).astype(cp.uint8)
+        if self.intensity_colormap is not None:
+            lut = cp.asarray(self.intensity_colormap)
+            colored = lut[idx]
+        else:
+            colored = cp.stack([idx, idx, idx], axis=-1)
+        out = colored.get().reshape(self.field.shape[0], self.field.shape[1], 3)
+        if overlay is not None:
+            out = cv2.add(overlay, out.astype(np.uint8))
+        return out.astype(np.uint8)
+
+
+def get_colormap_lut(name: str = 'afmhot', size: int = 256, invert: bool = False, black_level: float = 0.0) -> np.ndarray:
+    cmap = plt.get_cmap(name)
+    arr = cmap(np.linspace(0, 1, size))[:, :3]
+    if invert:
+        arr = 1.0 - arr
+    if black_level != 0.0:
+        arr = arr * (1.0 - black_level) + black_level
+    return (arr * 255).astype(np.uint8)


### PR DESCRIPTION
## Summary
- add new `wave_sim2d` package implementing a GPU wave solver
- include basic scene objects for dampening, refractive index and sources
- provide visualizer and video collage utilities
- update `examples/all_waves_collage.py` to use new simulator

## Testing
- `python -m py_compile $(git ls-files '*.py')`