### PR TITLE
Improve boundary logic and clarify placeholder waves

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ This repository contains a minimal framework for simulating and animating simple
 The repository now ships with implementations for **20** illustrative wave
 types collected in ``wave_sim.wave_catalog``.  These cover a mix of seismic,
 acoustic and fluid phenomena while all reusing the same underlying 2‑D solver
-for simplicity.
+for simplicity.  Surface and interface waves (Rayleigh, Love, Stoneley,
+Scholte, etc.) are provided only as minimal placeholders that reuse the scalar
+solver with preset speeds; they do not model full elastic boundary conditions.
 
 Legacy modules under ``wave_sim2d`` have been removed.  All animations now
 use the GPU optimised utilities found in ``wave_sim.high_quality`` which are
@@ -17,9 +19,9 @@ also able to fall back to NumPy when a CUDA device is not available.
 sources. The boundary condition can be selected when constructing a simulation
 via the `boundary` keyword with one of:
 
-* `"reflective"` – fixed edges (default)
+* `"reflective"` – zero normal derivative at the edges (mirror boundary)
 * `"periodic"` – domain repeats at the edges
-* `"absorbing"` – simple absorbing boundary
+* `"absorbing"` – damped sponge layer near the borders
 
 The initial disturbance can be provided through `initialize(source_func=...)`
 where `source_func` is a function of coordinate arrays ``(X, Y)``. For example,

--- a/wave_sim/base.py
+++ b/wave_sim/base.py
@@ -58,17 +58,22 @@ class WaveSimulation:
         )
         u_next = 2 * self.u_curr - self.u_prev + c2 * laplacian
         if self.boundary == "reflective":
-            u_next[0, :] = 0
-            u_next[-1, :] = 0
-            u_next[:, 0] = 0
-            u_next[:, -1] = 0
-        elif self.boundary == "periodic":
-            pass  # np.roll already provides periodic boundaries
-        elif self.boundary == "absorbing":
+            # Zero normal derivative at the domain edges (simple Neumann)
             u_next[0, :] = u_next[1, :]
             u_next[-1, :] = u_next[-2, :]
             u_next[:, 0] = u_next[:, 1]
             u_next[:, -1] = u_next[:, -2]
+        elif self.boundary == "periodic":
+            pass  # np.roll already provides periodic boundaries
+        elif self.boundary == "absorbing":
+            # Simple damped border acting as a sponge layer
+            damp = 8
+            for i in range(damp):
+                factor = (damp - i) / damp
+                u_next[i, :] *= factor
+                u_next[-1 - i, :] *= factor
+                u_next[:, i] *= factor
+                u_next[:, -1 - i] *= factor
         else:
             raise ValueError(f"Unknown boundary condition {self.boundary}")
         self.u_prev, self.u_curr = self.u_curr, u_next

--- a/wave_sim/solvers.py
+++ b/wave_sim/solvers.py
@@ -60,17 +60,20 @@ class ElasticWaveSimulation(WaveSimulation):
         u_next[sx, sy] += amp
 
         if self.boundary == "reflective":
-            u_next[0, :] = 0
-            u_next[-1, :] = 0
-            u_next[:, 0] = 0
-            u_next[:, -1] = 0
-        elif self.boundary == "periodic":
-            pass
-        elif self.boundary == "absorbing":
             u_next[0, :] = u_next[1, :]
             u_next[-1, :] = u_next[-2, :]
             u_next[:, 0] = u_next[:, 1]
             u_next[:, -1] = u_next[:, -2]
+        elif self.boundary == "periodic":
+            pass
+        elif self.boundary == "absorbing":
+            damp = 8
+            for i in range(damp):
+                factor = (damp - i) / damp
+                u_next[i, :] *= factor
+                u_next[-1 - i, :] *= factor
+                u_next[:, i] *= factor
+                u_next[:, -1 - i] *= factor
         else:
             raise ValueError(f"Unknown boundary condition {self.boundary}")
 

--- a/wave_sim/wave_catalog.py
+++ b/wave_sim/wave_catalog.py
@@ -1,9 +1,12 @@
 """Subset of wave simulations.
 
-This module defines minimal :class:`~wave_sim.base.WaveSimulation` subclasses
-for a curated list of wave types spanning seismic, acoustic and fluid
-phenomena.  Each class simply sets a default wave speed ``c`` and initialises
-the field with a unit impulse in the centre of the grid.
+The classes here are **simple demonstration wrappers** around
+:class:`~wave_sim.base.WaveSimulation`.  They merely choose convenient default
+wave speeds and initialise the field with a unit impulse.  The specialised
+surface/interface wave names (Rayleigh, Love, Stoneley, Scholte, etc.) do not
+implement the full elastic or multi-layer physics that would be required for
+realistic models.  They should therefore be viewed as *placeholders* useful for
+illustrative animations only.
 """
 
 import numpy as np
@@ -67,7 +70,12 @@ class SVWave(SVWaveSimulation):
 ###############################################################################
 
 class RayleighWave(WaveSimulation):
-    """Rayleigh surface wave."""
+    """Placeholder Rayleigh surface wave.
+
+    The real Rayleigh wave involves coupled traction-free elastic equations.
+    This simplified version merely solves a single scalar wave equation with a
+    default wave speed.
+    """
 
     def __init__(self, **kwargs):
         kwargs.setdefault("c", 0.53)
@@ -76,7 +84,11 @@ class RayleighWave(WaveSimulation):
 
 
 class LoveWave(WaveSimulation):
-    """Love surface wave."""
+    """Placeholder Love surface wave.
+
+    As with :class:`RayleighWave`, this is a minimal scalar solver and does not
+    implement layered shear wave physics.
+    """
 
     def __init__(self, **kwargs):
         kwargs.setdefault("c", 0.50)
@@ -85,7 +97,7 @@ class LoveWave(WaveSimulation):
 
 
 class LambS0Mode(WaveSimulation):
-    """Lamb S0 (symmetric) mode."""
+    """Placeholder Lamb S0 (symmetric) mode."""
 
     def __init__(self, **kwargs):
         kwargs.setdefault("c", 0.65)
@@ -94,7 +106,7 @@ class LambS0Mode(WaveSimulation):
 
 
 class LambA0Mode(WaveSimulation):
-    """Lamb A0 (antisymmetric) mode."""
+    """Placeholder Lamb A0 (antisymmetric) mode."""
 
     def __init__(self, **kwargs):
         kwargs.setdefault("c", 0.60)
@@ -103,7 +115,7 @@ class LambA0Mode(WaveSimulation):
 
 
 class StoneleyWave(WaveSimulation):
-    """Stoneley solid-solid interface wave."""
+    """Placeholder Stoneley solid-solid interface wave."""
 
     def __init__(self, **kwargs):
         kwargs.setdefault("c", 0.45)
@@ -112,7 +124,7 @@ class StoneleyWave(WaveSimulation):
 
 
 class ScholteWave(WaveSimulation):
-    """Scholte solid-fluid interface wave."""
+    """Placeholder Scholte solid-fluid interface wave."""
 
     def __init__(self, **kwargs):
         kwargs.setdefault("c", 0.40)


### PR DESCRIPTION
## Summary
- clarify in README that surface/interface wave classes are placeholders
- document new boundary behaviour in README
- mark Rayleigh/Love/Stoneley/Scholte and Lamb mode classes as placeholders
- implement zero-gradient reflective boundaries and damped absorbing edges
- add boundary handling to high quality GPU solver

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`
