### PR TITLE
Add full collage support and new 1D wave examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,8 @@ schemes in ``wave_sim.solvers``.  Surface and interface wave animations are
 **highly simplified**: they use a scalar wave model with preset speeds and do
 not capture the true dispersive or vector nature of these waves.
 
-Legacy modules under ``wave_sim2d`` have been removed.  All animations now
-use the GPU optimised utilities found in ``wave_sim.high_quality`` which are
-also able to fall back to NumPy when a CUDA device is not available.
+Legacy modules under ``wave_sim2d`` have been removed.  Animations for the ten 2‑D wave phenomena from ``wave_sim.wave_catalog`` (e.g., P, S, Rayleigh waves) are generated using the GPU‑optimised utilities in ``wave_sim.high_quality``.
+These can fall back to NumPy if a CUDA device is not available.  The other ten 1‑D or spectral wave types (e.g., Alfven, Rossby waves) from ``wave_sim.solvers`` are animated using ``matplotlib`` directly within their respective example scripts.
 
 ## Usage Notes
 
@@ -61,12 +60,9 @@ sv = SVWave()
 ux, uz = sv.get_displacement_components(frame, dx=1.0)
 ```
 
-Animations can be generated via ``examples/high_quality_collage.py`` which
-uses :mod:`wave_sim.high_quality` to produce movies for all twenty wave types.
-The script writes an MP4 per wave and then assembles the clips into a single
-collage video.  Because the 2‑D solver is a generic scalar model, only the
-body-wave examples are physically meaningful; the surface and interface waves
-are included purely for illustration.
+Animations for all twenty wave types can be generated and combined into a single collage video using ``examples/high_quality_collage.py``.
+This script utilizes :mod:`wave_sim.high_quality` for the 2‑D waves and calls the individual example scripts for the 1‑D/spectral waves.
+Because the 2‑D solver is a generic scalar model, only the body‑wave examples are physically meaningful; the surface and interface waves are included purely for illustration.
 
 
 Additional scripts in the ``examples`` directory demonstrate the specialised

--- a/examples/alfven_wave.py
+++ b/examples/alfven_wave.py
@@ -13,13 +13,20 @@ def v0(x):
     return np.sin(2 * np.pi * x / L)
 
 
-OUTPUT_DIR = "output_1d_animations"
+DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
 
 
-def generate_animation(out_name="alfven_wave.mp4"):
-    os.makedirs(OUTPUT_DIR, exist_ok=True)
-    out_path = os.path.join(OUTPUT_DIR, out_name)
-    sim = AlfvenWave(L=2.0, Nx=800, T=2.0)
+def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="alfven_wave.mp4"):
+    os.makedirs(output_dir, exist_ok=True)
+    out_path = os.path.join(output_dir, out_name)
+
+    sim_L = 2.0
+    sim_Nx = 800
+    sim_T = 2.0
+    dx = sim_L / sim_Nx
+    vA_sim = 1.0
+    dt_val = 0.5 * dx / vA_sim
+    sim = AlfvenWave(L=sim_L, Nx=sim_Nx, T=sim_T, dt=dt_val)
     sim.initial_conditions(v0)
     writer = imageio.get_writer(out_path, fps=30)
     fig, ax = plt.subplots(figsize=(8, 4))

--- a/examples/capillary_wave.py
+++ b/examples/capillary_wave.py
@@ -1,0 +1,61 @@
+"""Capillary wave example using the consolidated solver."""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import imageio.v2 as imageio
+import os
+
+from wave_sim import CapillaryWave
+from wave_sim.initial_conditions import gaussian_1d
+
+
+def eta0(x):
+    L = x[-1] + (x[1] - x[0])
+    return gaussian_1d(x, center=L/4, sigma=L/20)
+
+
+def deta0_dt(x):
+    return np.zeros_like(x)
+
+DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
+
+
+def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="capillary_wave.mp4"):
+    os.makedirs(output_dir, exist_ok=True)
+    out_path = os.path.join(output_dir, out_name)
+
+    L_domain = 2.0
+    Nx_points = 400
+    T_duration = 2.0
+    sigma_val = 0.072
+    rho_val = 1.0
+    dx_val = L_domain / Nx_points
+    dt_val = 0.5 * dx_val * np.sqrt(rho_val / sigma_val)
+
+    sim = CapillaryWave(L=L_domain, Nx=Nx_points, sigma=sigma_val, rho=rho_val, dt=dt_val, T=T_duration)
+    sim.initial_conditions(eta0, deta0_dt)
+
+    writer = imageio.get_writer(out_path, fps=30)
+    fig, ax = plt.subplots(figsize=(8, 4))
+
+    for i in range(sim.nt):
+        sim.step()
+        ax.clear()
+        ax.plot(sim.x, sim.eta_now)
+        ax.set_ylim(-0.5, 0.5)
+        ax.set_xlabel("x")
+        ax.set_ylabel("Surface displacement")
+        ax.set_title(f"Capillary Wave, Time: {i*sim.dt:.3f}s")
+        fig.canvas.draw()
+        img = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
+        img = img.reshape(fig.canvas.get_width_height()[::-1] + (3,))
+        writer.append_data(img)
+
+    writer.close()
+    plt.close(fig)
+    print(f"Generated 1D animation: {out_path}")
+    return out_path
+
+
+if __name__ == "__main__":
+    path = generate_animation()

--- a/examples/deep_water_gravity_wave.py
+++ b/examples/deep_water_gravity_wave.py
@@ -1,0 +1,60 @@
+"""Deep water gravity wave example using the consolidated solver."""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import imageio.v2 as imageio
+import os
+
+from wave_sim import DeepWaterGravityWave
+from wave_sim.initial_conditions import gaussian_1d
+
+
+def eta0(x):
+    L = x[-1] + (x[1] - x[0])
+    return gaussian_1d(x, center=L/4, sigma=L/20)
+
+
+def deta0_dt(x):
+    return np.zeros_like(x)
+
+DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
+
+
+def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="deep_water_gravity_wave.mp4"):
+    os.makedirs(output_dir, exist_ok=True)
+    out_path = os.path.join(output_dir, out_name)
+
+    L_domain = 2 * np.pi
+    Nx_points = 256
+    T_duration = 2.0
+    g_val = 9.81
+    dx_val = L_domain / Nx_points
+    dt_val = 0.5 * dx_val / np.sqrt(g_val)
+
+    sim = DeepWaterGravityWave(L=L_domain, Nx=Nx_points, g=g_val, dt=dt_val, T=T_duration)
+    sim.initial_conditions(eta0, deta0_dt)
+
+    writer = imageio.get_writer(out_path, fps=30)
+    fig, ax = plt.subplots(figsize=(8, 4))
+
+    for i in range(sim.nt):
+        sim.step()
+        ax.clear()
+        ax.plot(sim.x, sim.eta_now)
+        ax.set_ylim(-1.2, 1.2)
+        ax.set_xlabel("x")
+        ax.set_ylabel("Surface elevation")
+        ax.set_title(f"Deep Water Gravity Wave, Time: {i*sim.dt:.3f}s")
+        fig.canvas.draw()
+        img = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
+        img = img.reshape(fig.canvas.get_width_height()[::-1] + (3,))
+        writer.append_data(img)
+
+    writer.close()
+    plt.close(fig)
+    print(f"Generated 1D animation: {out_path}")
+    return out_path
+
+
+if __name__ == "__main__":
+    path = generate_animation()

--- a/examples/flexural_beam_wave.py
+++ b/examples/flexural_beam_wave.py
@@ -13,13 +13,20 @@ def w0(x):
     return np.exp(-100 * (x - L / 2) ** 2)
 
 
-OUTPUT_DIR = "output_1d_animations"
+DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
 
 
-def generate_animation(out_name="flexural_beam_wave.mp4"):
-    os.makedirs(OUTPUT_DIR, exist_ok=True)
-    out_path = os.path.join(OUTPUT_DIR, out_name)
-    sim = FlexuralBeamWave(L=2.0, Nx=801, T=5.0)
+def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="flexural_beam_wave.mp4"):
+    os.makedirs(output_dir, exist_ok=True)
+    out_path = os.path.join(output_dir, out_name)
+
+    sim_L = 2.0
+    sim_Nx = 801
+    sim_T = 5.0
+    dx = sim_L / (sim_Nx - 1)
+    D_val = 0.01
+    dt_val = 0.2 * dx ** 2 / np.sqrt(D_val)
+    sim = FlexuralBeamWave(D=D_val, L=sim_L, Nx=sim_Nx, T=sim_T, dt=dt_val)
     sim.initial_conditions(w0)
     writer = imageio.get_writer(out_path, fps=30)
     fig, ax = plt.subplots(figsize=(8, 4))

--- a/examples/high_quality_collage.py
+++ b/examples/high_quality_collage.py
@@ -18,9 +18,22 @@ import argparse
 
 from wave_sim.high_quality import simulate_wave, PointSource, ConstantSpeed
 from wave_sim.collage import collage_videos
+from wave_sim.core.boundary import BoundaryCondition
+
+# Import generators for 1D/spectral animations
+from examples.alfven_wave import generate_animation as generate_alfven_animation
+from examples.flexural_beam_wave import generate_animation as generate_flexural_animation
+from examples.internal_gravity_wave import generate_animation as generate_internal_gravity_animation
+from examples.kelvin_wave import generate_animation as generate_kelvin_animation
+from examples.rossby_planetary_wave import generate_animation as generate_rossby_animation
+from examples.plane_acoustic_wave import generate_animation as generate_plane_acoustic_animation
+from examples.spherical_acoustic_wave import generate_animation as generate_spherical_acoustic_animation
+from examples.deep_water_gravity_wave import generate_animation as generate_deep_water_animation
+from examples.shallow_water_gravity_wave import generate_animation as generate_shallow_water_animation
+from examples.capillary_wave import generate_animation as generate_capillary_animation
 
 
-WAVE_CLASSES = [
+WAVE_CLASSES_2D = [
     PrimaryWave,
     SecondaryWave,
     SHWave,
@@ -31,6 +44,19 @@ WAVE_CLASSES = [
     LambA0Mode,
     StoneleyWave,
     ScholteWave,
+]
+
+ONE_D_SPECTRAL_ANIMATIONS_CONFIG = [
+    (generate_alfven_animation, "alfven_wave"),
+    (generate_flexural_animation, "flexural_beam_wave"),
+    (generate_internal_gravity_animation, "internal_gravity_wave"),
+    (generate_kelvin_animation, "kelvin_wave"),
+    (generate_rossby_animation, "rossby_planetary_wave"),
+    (generate_plane_acoustic_animation, "plane_acoustic_wave"),
+    (generate_spherical_acoustic_animation, "spherical_acoustic_wave"),
+    (generate_deep_water_animation, "deep_water_gravity_wave"),
+    (generate_shallow_water_animation, "shallow_water_gravity_wave"),
+    (generate_capillary_animation, "capillary_wave"),
 ]
 
 
@@ -49,7 +75,8 @@ def build_scene_factory(speed):
 def run_all(args):
     os.makedirs(args.outdir, exist_ok=True)
     files = []
-    for cls in WAVE_CLASSES:
+    print("Generating 2D wave animations...")
+    for cls in WAVE_CLASSES_2D:
         speed = get_wave_speed(cls)
         name = cls.__name__.lower()
         outfile = os.path.join(args.outdir, f"{name}.mp4")
@@ -60,22 +87,30 @@ def run_all(args):
             sim_steps_per_frame=args.sim_steps_per_frame,
             resolution=(args.resolution, args.resolution),
             fps=args.fps,
-            backend="gpu",
-            boundary_condition=args.boundary,
+            backend=args.backend,
+            boundary_condition=BoundaryCondition(args.boundary),
         )
         files.append(outfile)
-    collage_videos(files, os.path.join(args.outdir, "collage.mp4"), fps=args.fps, mode=args.mode)
+
+    print("\nGenerating 1D/spectral wave animations...")
+    for generator_func, base_name in ONE_D_SPECTRAL_ANIMATIONS_CONFIG:
+        out_name_1d = f"{base_name}.mp4"
+        generated_path = generator_func(output_dir=args.outdir, out_name=out_name_1d)
+        files.append(generated_path)
+
+    collage_videos(files, os.path.join(args.outdir, "collage_all.mp4"), fps=args.fps, mode=args.mode)
 
 
 def parse_args():
     p = argparse.ArgumentParser(description="Run high quality wave simulations and build a collage")
-    p.add_argument("--outdir", default="output_hq", help="directory for individual videos")
+    p.add_argument("--outdir", default="output_all_waves_collage", help="directory for individual videos and collage")
     p.add_argument("--resolution", type=int, default=256, help="simulation width/height in pixels")
     p.add_argument("--steps", type=int, default=300, help="number of simulation steps")
     p.add_argument("--sim-steps-per-frame", type=int, default=2, help="steps per rendered frame")
     p.add_argument("--fps", type=int, default=30, help="frames per second")
     p.add_argument("--mode", choices=["grid", "horizontal", "vertical", "overlay"], default="grid", help="collage layout mode")
     p.add_argument("--boundary", choices=["reflective", "periodic", "absorbing"], default="absorbing", help="boundary condition")
+    p.add_argument("--backend", choices=["gpu", "cpu", "auto"], default="auto", help="computation backend for 2D waves")
     return p.parse_args()
 
 

--- a/examples/internal_gravity_wave.py
+++ b/examples/internal_gravity_wave.py
@@ -12,13 +12,20 @@ def psi0(x):
     return np.exp(-100 * (x - 1.0) ** 2)
 
 
-OUTPUT_DIR = "output_1d_animations"
+DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
 
 
-def generate_animation(out_name="internal_gravity_wave.mp4"):
-    os.makedirs(OUTPUT_DIR, exist_ok=True)
-    out_path = os.path.join(OUTPUT_DIR, out_name)
-    sim = InternalGravityWave(L=2.0, Nx=800, T=3.0)
+def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="internal_gravity_wave.mp4"):
+    os.makedirs(output_dir, exist_ok=True)
+    out_path = os.path.join(output_dir, out_name)
+
+    sim_L = 2.0
+    sim_Nx = 800
+    sim_T = 3.0
+    dx = sim_L / sim_Nx
+    N_val = 1.0
+    dt_val = 0.8 * dx / N_val
+    sim = InternalGravityWave(L=sim_L, Nx=sim_Nx, T=sim_T, dt=dt_val)
     sim.initial_conditions(psi0)
     writer = imageio.get_writer(out_path, fps=30)
     fig, ax = plt.subplots(figsize=(8, 4))

--- a/examples/kelvin_wave.py
+++ b/examples/kelvin_wave.py
@@ -12,13 +12,20 @@ def eta0(y):
     return np.exp(-((y - 2.5) / 0.5) ** 2)
 
 
-OUTPUT_DIR = "output_1d_animations"
+DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
 
 
-def generate_animation(out_name="kelvin_wave.mp4"):
-    os.makedirs(OUTPUT_DIR, exist_ok=True)
-    out_path = os.path.join(OUTPUT_DIR, out_name)
-    sim = KelvinWave(L=10.0, Ny=800, T=10.0)
+def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="kelvin_wave.mp4"):
+    os.makedirs(output_dir, exist_ok=True)
+    out_path = os.path.join(output_dir, out_name)
+
+    sim_L = 10.0
+    sim_Ny = 800
+    sim_T = 10.0
+    dy = sim_L / (sim_Ny - 1)
+    c = np.sqrt(9.81 * 1.0)
+    dt_val = 0.4 * dy / c
+    sim = KelvinWave(L=sim_L, Ny=sim_Ny, T=sim_T, dt=dt_val)
     sim.initial_conditions(eta0)
     writer = imageio.get_writer(out_path, fps=30)
     fig, ax = plt.subplots(figsize=(8, 4))

--- a/examples/plane_acoustic_wave.py
+++ b/examples/plane_acoustic_wave.py
@@ -1,0 +1,59 @@
+"""Plane acoustic wave example using the consolidated solver."""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import imageio.v2 as imageio
+import os
+
+from wave_sim import PlaneAcousticWave
+from wave_sim.initial_conditions import gaussian_1d
+
+
+def p0_initial(x):
+    L = x[-1] if x.size > 0 else 1.0
+    return gaussian_1d(x, center=L/4, sigma=L/20)
+
+def dp0_dt_initial(x):
+    return np.zeros_like(x)
+
+DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
+
+
+def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="plane_acoustic_wave.mp4"):
+    os.makedirs(output_dir, exist_ok=True)
+    out_path = os.path.join(output_dir, out_name)
+
+    L_domain = 1.0
+    Nx_points = 400
+    T_duration = 2.0
+    c_speed = 1.0
+    dx_val = L_domain / Nx_points
+    dt_val = 0.5 * dx_val / c_speed
+
+    sim = PlaneAcousticWave(c=c_speed, L=L_domain, Nx=Nx_points, dt=dt_val, T=T_duration)
+    sim.initial_conditions(p0_initial, dp_init_func=dp0_dt_initial)
+
+    writer = imageio.get_writer(out_path, fps=30)
+    fig, ax = plt.subplots(figsize=(8, 4))
+
+    for i in range(sim.nt):
+        sim.step()
+        ax.clear()
+        ax.plot(sim.x, sim.p_now)
+        ax.set_ylim(-1.2, 1.2)
+        ax.set_xlabel("x")
+        ax.set_ylabel("Pressure p(x,t)")
+        ax.set_title(f"Plane Acoustic Wave, Time: {i*sim.dt:.3f}s")
+        fig.canvas.draw()
+        img = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
+        img = img.reshape(fig.canvas.get_width_height()[::-1] + (3,))
+        writer.append_data(img)
+
+    writer.close()
+    plt.close(fig)
+    print(f"Generated 1D animation: {out_path}")
+    return out_path
+
+
+if __name__ == "__main__":
+    path = generate_animation()

--- a/examples/rossby_planetary_wave.py
+++ b/examples/rossby_planetary_wave.py
@@ -14,12 +14,13 @@ def psi0(X, Y):
     return np.exp(-((X - Lx / 2) ** 2 + (Y - Ly / 2) ** 2) / 0.2)
 
 
-OUTPUT_DIR = "output_1d_animations"
+DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
 
 
-def generate_animation(out_name="rossby_planetary_wave.mp4"):
-    os.makedirs(OUTPUT_DIR, exist_ok=True)
-    out_path = os.path.join(OUTPUT_DIR, out_name)
+def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="rossby_planetary_wave.mp4"):
+    os.makedirs(output_dir, exist_ok=True)
+    out_path = os.path.join(output_dir, out_name)
+
     sim = RossbyPlanetaryWave(Nx=256, Ny=256, T=3.0)
     sim.initial_conditions(psi0)
     X, Y = np.meshgrid(

--- a/examples/shallow_water_gravity_wave.py
+++ b/examples/shallow_water_gravity_wave.py
@@ -1,0 +1,60 @@
+"""Shallow water gravity wave example using the consolidated solver."""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import imageio.v2 as imageio
+import os
+
+from wave_sim import ShallowWaterGravityWave
+from wave_sim.initial_conditions import gaussian_1d
+
+
+def h0(x):
+    L = x[-1] + (x[1] - x[0])
+    return 1.0 + 0.1 * gaussian_1d(x, center=L/4, sigma=L/20)
+
+
+def u0(x):
+    return np.zeros_like(x)
+
+DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
+
+
+def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="shallow_water_gravity_wave.mp4"):
+    os.makedirs(output_dir, exist_ok=True)
+    out_path = os.path.join(output_dir, out_name)
+
+    L_domain = 10.0
+    Nx_points = 200
+    T_duration = 2.0
+    g_val = 9.81
+    dx_val = L_domain / Nx_points
+    dt_val = 0.5 * dx_val / np.sqrt(g_val)
+
+    sim = ShallowWaterGravityWave(g=g_val, L=L_domain, Nx=Nx_points, dt=dt_val, T=T_duration)
+    sim.initial_conditions(h0, u0)
+
+    writer = imageio.get_writer(out_path, fps=30)
+    fig, ax = plt.subplots(figsize=(8, 4))
+
+    for i in range(sim.nt):
+        sim.step()
+        ax.clear()
+        ax.plot(sim.x, sim.Q[0, :])
+        ax.set_ylim(0.8, 1.2)
+        ax.set_xlabel("x")
+        ax.set_ylabel("Water height")
+        ax.set_title(f"Shallow Water Gravity Wave, Time: {i*sim.dt:.3f}s")
+        fig.canvas.draw()
+        img = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
+        img = img.reshape(fig.canvas.get_width_height()[::-1] + (3,))
+        writer.append_data(img)
+
+    writer.close()
+    plt.close(fig)
+    print(f"Generated 1D animation: {out_path}")
+    return out_path
+
+
+if __name__ == "__main__":
+    path = generate_animation()

--- a/examples/spherical_acoustic_wave.py
+++ b/examples/spherical_acoustic_wave.py
@@ -1,0 +1,60 @@
+"""Spherical acoustic wave example using the consolidated solver."""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import imageio.v2 as imageio
+import os
+
+from wave_sim import SphericalAcousticWave
+from wave_sim.initial_conditions import gaussian_1d
+
+
+def p0_initial(r):
+    R = r[-1] if r.size > 0 else 2.0
+    return gaussian_1d(r, center=R/4, sigma=R/20)
+
+
+def dp0_dt_initial(r):
+    return np.zeros_like(r)
+
+DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
+
+
+def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="spherical_acoustic_wave.mp4"):
+    os.makedirs(output_dir, exist_ok=True)
+    out_path = os.path.join(output_dir, out_name)
+
+    R_domain = 2.0
+    Nr_points = 400
+    T_duration = 2.0
+    c_speed = 1.0
+    dr_val = R_domain / Nr_points
+    dt_val = 0.5 * dr_val / c_speed
+
+    sim = SphericalAcousticWave(c=c_speed, R=R_domain, Nr=Nr_points, dt=dt_val, T=T_duration)
+    sim.initial_conditions(p0_initial, dp_init_func=dp0_dt_initial)
+
+    writer = imageio.get_writer(out_path, fps=30)
+    fig, ax = plt.subplots(figsize=(8, 4))
+
+    for i in range(sim.nt):
+        sim.step()
+        ax.clear()
+        ax.plot(sim.r, sim.p_now)
+        ax.set_ylim(-1.2, 1.2)
+        ax.set_xlabel("r")
+        ax.set_ylabel("Pressure p(r,t)")
+        ax.set_title(f"Spherical Acoustic Wave, Time: {i*sim.dt:.3f}s")
+        fig.canvas.draw()
+        img = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
+        img = img.reshape(fig.canvas.get_width_height()[::-1] + (3,))
+        writer.append_data(img)
+
+    writer.close()
+    plt.close(fig)
+    print(f"Generated 1D animation: {out_path}")
+    return out_path
+
+
+if __name__ == "__main__":
+    path = generate_animation()


### PR DESCRIPTION
## Summary
- clarify GPU usage and collage behaviour in README
- standardize example scripts with new output_dir arguments and CFL-based `dt`
- add example scripts for missing 1D/spectral waves
- extend `high_quality_collage.py` to run all 20 animations and include backend option

## Testing
- `pytest -q`