### PR TITLE
Consolidate GPU solver and add modulators

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ simulate_wave(scene, "out.mp4", steps=200, resolution=(256, 256))
 ```
 
 The scene object collection also includes ``LineSource`` for emitting waves
-along an arbitrary segment and ``ModulatorSmoothSquare`` for smoothly pulsing
-source amplitudes.
+along an arbitrary segment and ``ModulatorSmoothSquare`` or
+``ModulatorDiscreteSignal`` for smoothly or discretely pulsing source
+amplitudes.
 
 The solver emits a warning if the CFL condition ``c * dt / dx`` exceeds
 ``1 / sqrt(2)`` to help maintain stability.

--- a/examples/rossby_planetary_wave.py
+++ b/examples/rossby_planetary_wave.py
@@ -32,7 +32,7 @@ def generate_animation(out_name="rossby_planetary_wave.mp4"):
     for _ in range(sim.nt):
         sim.step()
         ax.clear()
-        cf = ax.contourf(X, Y, sim.psi, levels=20, cmap="RdBu_r")
+        ax.contourf(X, Y, sim.psi, levels=20, cmap="RdBu_r")
         ax.set_xlabel("x")
         ax.set_ylabel("y")
         fig.canvas.draw()
@@ -47,4 +47,3 @@ def generate_animation(out_name="rossby_planetary_wave.mp4"):
 if __name__ == "__main__":
     path = generate_animation()
     print(f"Wrote {path}")
-

--- a/tests/test_high_quality.py
+++ b/tests/test_high_quality.py
@@ -1,0 +1,28 @@
+import pytest
+
+from wave_sim.high_quality import (
+    WaveSimulator2D,
+    ConstantSpeed,
+    PointSource,
+    get_colormap_lut,
+)
+
+
+@pytest.mark.parametrize("backend", ["cpu", "gpu"])
+def test_simulator_backend(backend):
+    try:
+        sim = WaveSimulator2D(
+            32, 32, [ConstantSpeed(1.0), PointSource(16, 16)], backend=backend
+        )
+    except Exception:
+        pytest.skip(f"backend {backend} not available")
+    for _ in range(3):
+        sim.update_scene()
+        sim.update_field()
+    assert sim.get_field() is not None
+
+
+def test_colormap_names():
+    for name in ["wave1", "wave2", "wave3", "wave4", "icefire"]:
+        lut = get_colormap_lut(name)
+        assert lut.shape == (256, 3)

--- a/wave_sim/high_quality/__init__.py
+++ b/wave_sim/high_quality/__init__.py
@@ -13,6 +13,8 @@ from .scene_objects import (
     StaticRefractiveIndexPolygon,
     LineSource,
     ModulatorSmoothSquare,
+    ModulatorDiscreteSignal,
+    MovingPointSource,
 )
 
 __all__ = [
@@ -30,4 +32,6 @@ __all__ = [
     "StaticRefractiveIndexPolygon",
     "LineSource",
     "ModulatorSmoothSquare",
+    "ModulatorDiscreteSignal",
+    "MovingPointSource",
 ]

--- a/wave_sim/high_quality/runner.py
+++ b/wave_sim/high_quality/runner.py
@@ -1,21 +1,25 @@
-import os
 import imageio.v2 as imageio
-import numpy as np
-import cv2
 
 from .simulator import WaveSimulator2D
 from ..core.boundary import BoundaryCondition
 from .visualizer import WaveVisualizer, get_colormap_lut
 
 
-def simulate_wave(scene_builder, out_path, steps=2000, sim_steps_per_frame=8,
-                  resolution=(512, 512), fps=60, backend="gpu",
-                  boundary_condition=BoundaryCondition.REFLECTIVE, global_dampening=1.0):
+def simulate_wave(
+    scene_builder,
+    out_path,
+    steps=2000,
+    sim_steps_per_frame=8,
+    resolution=(512, 512),
+    fps=60,
+    backend="gpu",
+    boundary_condition=BoundaryCondition.REFLECTIVE,
+    global_dampening=1.0,
+):
     """Run a high quality simulation and save to MP4."""
     objects, w, h, init = scene_builder(resolution)
     sim = WaveSimulator2D(
-        w, h, objects, initial_field=init,
-        backend=backend, boundary=boundary_condition
+        w, h, objects, initial_field=init, backend=backend, boundary=boundary_condition
     )
     sim.global_dampening = global_dampening
     vis = WaveVisualizer(

--- a/wave_sim/high_quality/simulator.py
+++ b/wave_sim/high_quality/simulator.py
@@ -39,8 +39,17 @@ class WaveSimulator2D:
         Spatial resolution of the grid.  ``laplacian`` is scaled by ``1/dx^2``.
     """
 
-    def __init__(self, width, height, scene_objects=None, initial_field=None,
-                 backend="gpu", boundary=BoundaryCondition.REFLECTIVE, dx=1.0, dt=1.0):
+    def __init__(
+        self,
+        width,
+        height,
+        scene_objects=None,
+        initial_field=None,
+        backend="gpu",
+        boundary=BoundaryCondition.REFLECTIVE,
+        dx=1.0,
+        dt=1.0,
+    ):
         self.xp = get_array_module(backend)
         xp = self.xp
 
@@ -91,6 +100,7 @@ class WaveSimulator2D:
             bmode = "fill"
         if xp.__name__ == "cupy":
             import cupyx.scipy.signal  # type: ignore
+
             laplacian = xp.asarray(
                 cupyx.scipy.signal.convolve2d(
                     self.u, self.laplacian_kernel, mode="same", boundary=bmode
@@ -123,7 +133,6 @@ class WaveSimulator2D:
         return self.u
 
     def render_visualization(self, image=None):
-        xp = self.xp
         if image is None:
             image = np.zeros((self.c.shape[0], self.c.shape[1], 3), dtype=np.uint8)
         for obj in self.scene_objects:

--- a/wave_sim/high_quality/visualizer.py
+++ b/wave_sim/high_quality/visualizer.py
@@ -6,20 +6,35 @@ except Exception:  # pragma: no cover - optional dependency
     cp = None
 
 import cv2
-
+import matplotlib.pyplot as plt
 from .simulator import WaveSimulator2D
 
 # Predefined colormaps from the reference
-colormap_wave1 = np.array([
-    [255, 255, 255], [254, 254, 253], [254, 253, 252], [253, 252, 250],
-    [253, 250, 248], [252, 249, 246], [252, 248, 244], [251, 246, 242],
-    [251, 245, 240], [250, 243, 237], [250, 242, 235], [249, 240, 232],
-    [248, 238, 230], [248, 237, 227], [247, 235, 224], [247, 233, 221],
-    [246, 231, 218], [245, 229, 215], [245, 227, 212], [244, 225, 209],
-])
+colormap_wave1 = np.array(
+    [
+        [255, 255, 255],
+        [254, 254, 253],
+        [254, 253, 252],
+        [253, 252, 250],
+        [253, 250, 248],
+        [252, 249, 246],
+        [252, 248, 244],
+        [251, 246, 242],
+        [251, 245, 240],
+        [250, 243, 237],
+        [250, 242, 235],
+        [249, 240, 232],
+        [248, 238, 230],
+        [248, 237, 227],
+        [247, 235, 224],
+        [247, 233, 221],
+        [246, 231, 218],
+        [245, 229, 215],
+        [245, 227, 212],
+        [244, 225, 209],
+    ]
+)
 
-
-import matplotlib.pyplot as plt
 
 __LUT_CACHE = {}
 
@@ -43,7 +58,10 @@ def get_colormap_lut(
         t256 = np.linspace(0, 1, 256)
         colors = np.vstack([np.interp(t256, t, base[:, ch]) for ch in range(3)]).T
     else:
-        colors = plt.get_cmap(name)(np.linspace(0, 1, 256))[:, :3]
+        try:
+            colors = plt.get_cmap(name)(np.linspace(0, 1, 256))[:, :3]
+        except Exception:  # pragma: no cover - unknown cmap name
+            colors = plt.get_cmap("viridis")(np.linspace(0, 1, 256))[:, :3]
 
     if invert:
         colors = 1.0 - colors
@@ -71,13 +89,21 @@ class WaveVisualizer:
         if self.intensity is None:
             self.intensity = xp.zeros_like(self.field)
         t = self.intensity_exp_average_factor
-        self.intensity = self.intensity * t + (self.field ** 2) * (1.0 - t)
+        self.intensity = self.intensity * t + (self.field**2) * (1.0 - t)
         self.visualization_image = sim.render_visualization()
 
-    def render_intensity(self, brightness_scale=1.0, exp=0.5, overlay_visualization=True):
+    def render_intensity(
+        self, brightness_scale=1.0, exp=0.5, overlay_visualization=True
+    ):
         xp = cp if cp is not None and isinstance(self.intensity, cp.ndarray) else np
-        gray = (xp.clip((self.intensity ** exp) * brightness_scale, 0.0, 1.0) * 254.0).astype(np.uint8)
-        img = self.intensity_colormap[gray.get()] if xp is cp else self.intensity_colormap[gray]
+        gray = (
+            xp.clip((self.intensity**exp) * brightness_scale, 0.0, 1.0) * 254.0
+        ).astype(np.uint8)
+        img = (
+            self.intensity_colormap[gray.get()]
+            if xp is cp
+            else self.intensity_colormap[gray]
+        )
         img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
         if overlay_visualization:
             img = cv2.add(img, self.visualization_image)
@@ -85,7 +111,9 @@ class WaveVisualizer:
 
     def render_field(self, brightness_scale=1.0, overlay_visualization=True):
         xp = cp if cp is not None and isinstance(self.field, cp.ndarray) else np
-        gray = (xp.clip(self.field * brightness_scale, -1.0, 1.0) * 127 + 127).astype(np.uint8)
+        gray = (xp.clip(self.field * brightness_scale, -1.0, 1.0) * 127 + 127).astype(
+            np.uint8
+        )
         img = self.field_colormap[gray.get()] if xp is cp else self.field_colormap[gray]
         img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
         if overlay_visualization:

--- a/wave_sim/solvers.py
+++ b/wave_sim/solvers.py
@@ -16,7 +16,14 @@ from typing import Optional
 class PlaneAcousticWave:
     """Solve the one-dimensional acoustic wave equation."""
 
-    def __init__(self, c: float = 1.0, L: float = 1.0, Nx: int = 200, dt: float = 0.001, T: float = 1.0) -> None:
+    def __init__(
+        self,
+        c: float = 1.0,
+        L: float = 1.0,
+        Nx: int = 200,
+        dt: float = 0.001,
+        T: float = 1.0,
+    ) -> None:
         self.c = c
         self.L = L
         self.Nx = Nx
@@ -46,8 +53,8 @@ class PlaneAcousticWave:
         arr[-1] = 0.0
 
     def step(self) -> None:
-        c2 = self.c ** 2
-        r = c2 * (self.dt ** 2 / self.dx ** 2)
+        c2 = self.c**2
+        r = c2 * (self.dt**2 / self.dx**2)
         for i in range(1, self.Nx):
             self.p_next[i] = (
                 2.0 * self.p_now[i]
@@ -68,7 +75,14 @@ class PlaneAcousticWave:
 class SphericalAcousticWave:
     """Solve the spherically symmetric acoustic wave equation."""
 
-    def __init__(self, c: float = 1.0, R: float = 2.0, Nr: int = 200, dt: float = 0.001, T: float = 1.0) -> None:
+    def __init__(
+        self,
+        c: float = 1.0,
+        R: float = 2.0,
+        Nr: int = 200,
+        dt: float = 0.001,
+        T: float = 1.0,
+    ) -> None:
         self.c = c
         self.R = R
         self.Nr = Nr
@@ -97,7 +111,7 @@ class SphericalAcousticWave:
         arr[-1] = 0.0
 
     def step(self) -> None:
-        rfac = self.c ** 2 * self.dt ** 2 / (self.dr ** 2)
+        rfac = self.c**2 * self.dt**2 / (self.dr**2)
         for i in range(1, self.Nr):
             r_i = self.r[i]
             dpdr_plus = self.p_now[i + 1] - self.p_now[i]
@@ -107,7 +121,7 @@ class SphericalAcousticWave:
             self.p_next[i] = (
                 2.0 * self.p_now[i]
                 - self.p_prev[i]
-                + rfac * (term_plus - term_minus) / ((r_i ** 2) * self.dr)
+                + rfac * (term_plus - term_minus) / ((r_i**2) * self.dr)
             )
         self.apply_boundary_conditions(self.p_next)
         self.p_prev, self.p_now, self.p_next = self.p_now, self.p_next, self.p_prev
@@ -123,7 +137,14 @@ class SphericalAcousticWave:
 class DeepWaterGravityWave:
     """Spectral solver for 1-D deep-water gravity waves."""
 
-    def __init__(self, L: float = 2 * np.pi, Nx: int = 256, g: float = 9.81, dt: float = 0.01, T: float = 2.0) -> None:
+    def __init__(
+        self,
+        L: float = 2 * np.pi,
+        Nx: int = 256,
+        g: float = 9.81,
+        dt: float = 0.01,
+        T: float = 2.0,
+    ) -> None:
         self.L = L
         self.Nx = Nx
         self.dx = L / Nx
@@ -152,7 +173,7 @@ class DeepWaterGravityWave:
         eta_hat_next = np.zeros_like(self.eta_hat_now, dtype=np.complex128)
         for i in range(len(self.k)):
             k_abs = abs(self.k[i])
-            alpha = self.g * k_abs * (self.dt ** 2)
+            alpha = self.g * k_abs * (self.dt**2)
             eta_hat_next[i] = (2.0 - alpha) * self.eta_hat_now[i] - self.eta_hat_prev[i]
         self.eta_hat_prev = self.eta_hat_now
         self.eta_hat_now = eta_hat_next
@@ -169,7 +190,14 @@ class DeepWaterGravityWave:
 class ShallowWaterGravityWave:
     """Rusanov finite-volume solver for 1-D shallow water equations."""
 
-    def __init__(self, g: float = 9.81, L: float = 10.0, Nx: int = 200, dt: float = 0.001, T: float = 2.0) -> None:
+    def __init__(
+        self,
+        g: float = 9.81,
+        L: float = 10.0,
+        Nx: int = 200,
+        dt: float = 0.001,
+        T: float = 2.0,
+    ) -> None:
         self.g = g
         self.L = L
         self.Nx = Nx
@@ -238,7 +266,15 @@ class ShallowWaterGravityWave:
 class CapillaryWave:
     """Finite-difference solver for linear capillary waves."""
 
-    def __init__(self, L: float = 2 * np.pi, Nx: int = 256, sigma: float = 0.074, rho: float = 1000.0, dt: float = 0.0001, T: float = 0.1) -> None:
+    def __init__(
+        self,
+        L: float = 2 * np.pi,
+        Nx: int = 256,
+        sigma: float = 0.074,
+        rho: float = 1000.0,
+        dt: float = 0.0001,
+        T: float = 0.1,
+    ) -> None:
         self.L = L
         self.Nx = Nx
         self.dx = L / Nx
@@ -272,11 +308,15 @@ class CapillaryWave:
         )
 
     def step(self) -> None:
-        coef = (self.sigma / self.rho) * (self.dt ** 2) / (self.dx ** 4)
+        coef = (self.sigma / self.rho) * (self.dt**2) / (self.dx**4)
         for i in range(self.Nx):
             d4 = self.fourth_deriv(self.eta_now, i)
             self.eta_next[i] = 2.0 * self.eta_now[i] - self.eta_prev[i] - coef * d4
-        self.eta_prev, self.eta_now, self.eta_next = self.eta_now, self.eta_next, self.eta_prev
+        self.eta_prev, self.eta_now, self.eta_next = (
+            self.eta_now,
+            self.eta_next,
+            self.eta_prev,
+        )
 
     def solve(self) -> np.ndarray:
         snapshots = [self.eta_now.copy()]
@@ -293,7 +333,14 @@ class InternalGravityWave:
     differences in space and time.
     """
 
-    def __init__(self, N: float = 1.0, L: float = 2.0, Nx: int = 800, dt: Optional[float] = None, T: float = 1.0) -> None:
+    def __init__(
+        self,
+        N: float = 1.0,
+        L: float = 2.0,
+        Nx: int = 800,
+        dt: Optional[float] = None,
+        T: float = 1.0,
+    ) -> None:
         c = N
         self.N = N
         self.L = L
@@ -320,17 +367,22 @@ class InternalGravityWave:
             self.psi_prev[:] = self.psi_now[:]
 
     def step(self) -> None:
-        c2 = self.N ** 2
-        r = c2 * (self.dt ** 2 / self.dx ** 2)
+        c2 = self.N**2
+        r = c2 * (self.dt**2 / self.dx**2)
         for i in range(1, self.Nx):
             self.psi_next[i] = (
                 2.0 * self.psi_now[i]
                 - self.psi_prev[i]
-                + r * (self.psi_now[i + 1] - 2.0 * self.psi_now[i] + self.psi_now[i - 1])
+                + r
+                * (self.psi_now[i + 1] - 2.0 * self.psi_now[i] + self.psi_now[i - 1])
             )
         self.psi_next[0] = 0.0
         self.psi_next[-1] = 0.0
-        self.psi_prev, self.psi_now, self.psi_next = self.psi_now, self.psi_next, self.psi_prev
+        self.psi_prev, self.psi_now, self.psi_next = (
+            self.psi_now,
+            self.psi_next,
+            self.psi_prev,
+        )
 
     def solve(self) -> np.ndarray:
         sol = [self.psi_now.copy()]
@@ -352,7 +404,16 @@ class KelvinWave:
     with centred finite differences along the ``y`` direction.
     """
 
-    def __init__(self, L: float = 10.0, Ny: int = 800, H: float = 1.0, f: float = 1.0, g: float = 9.81, dt: Optional[float] = None, T: float = 10.0) -> None:
+    def __init__(
+        self,
+        L: float = 10.0,
+        Ny: int = 800,
+        H: float = 1.0,
+        f: float = 1.0,
+        g: float = 9.81,
+        dt: Optional[float] = None,
+        T: float = 10.0,
+    ) -> None:
         self.L = L
         self.Ny = Ny
         self.dy = L / (Ny - 1)
@@ -379,14 +440,16 @@ class KelvinWave:
         v_new = self.v.copy()
         eta_new = self.eta.copy()
         for j in range(1, self.Ny - 1):
-            du = -self.g * (self.eta[j + 1] - self.eta[j - 1]) / (2 * self.dy) + self.f * self.v[j]
+            du = (
+                -self.g * (self.eta[j + 1] - self.eta[j - 1]) / (2 * self.dy)
+                + self.f * self.v[j]
+            )
             dv = -self.f * self.u[j]
             deta = -self.H * (self.u[j + 1] - self.u[j - 1]) / (2 * self.dy)
             u_new[j] = self.u[j] + self.dt * du
             v_new[j] = self.v[j] + self.dt * dv
             eta_new[j] = self.eta[j] + self.dt * deta
         # Left boundary (coast): u=0, one-sided differences for eta and u gradients
-        du0 = -self.g * (self.eta[1] - self.eta[0]) / self.dy + self.f * self.v[0]
         dv0 = -self.f * self.u[0]
         deta0 = -self.H * (self.u[1] - self.u[0]) / self.dy
         u_new[0] = 0.0
@@ -413,7 +476,16 @@ class RossbyPlanetaryWave:
     Integrates ``(∇²ψ)_t + β ψ_x = 0`` on a periodic domain using FFTs.
     """
 
-    def __init__(self, Nx: int = 256, Ny: int = 256, Lx: float = 2 * np.pi, Ly: float = 2 * np.pi, beta: float = 1.0, dt: float = 0.01, T: float = 2.0) -> None:
+    def __init__(
+        self,
+        Nx: int = 256,
+        Ny: int = 256,
+        Lx: float = 2 * np.pi,
+        Ly: float = 2 * np.pi,
+        beta: float = 1.0,
+        dt: float = 0.01,
+        T: float = 2.0,
+    ) -> None:
         self.Nx = Nx
         self.Ny = Ny
         self.Lx = Lx
@@ -428,7 +500,7 @@ class RossbyPlanetaryWave:
         self.kx = np.fft.fftfreq(Nx, d=self.dx) * 2 * np.pi
         self.ky = np.fft.fftfreq(Ny, d=self.dy) * 2 * np.pi
         self.kx2D, self.ky2D = np.meshgrid(self.kx, self.ky, indexing="ij")
-        self.k2 = self.kx2D ** 2 + self.ky2D ** 2
+        self.k2 = self.kx2D**2 + self.ky2D**2
         self.k2[0, 0] = 1e-14
 
         self.psi_hat = np.zeros((Nx, Ny), dtype=np.complex128)
@@ -465,14 +537,21 @@ class FlexuralBeamWave:
     in space and a leapfrog update in time.
     """
 
-    def __init__(self, D: float = 0.01, L: float = 2.0, Nx: int = 801, dt: Optional[float] = None, T: float = 5.0) -> None:
+    def __init__(
+        self,
+        D: float = 0.01,
+        L: float = 2.0,
+        Nx: int = 801,
+        dt: Optional[float] = None,
+        T: float = 5.0,
+    ) -> None:
         self.D = D
         self.L = L
         self.Nx = Nx
         self.x = np.linspace(0, L, Nx)
         self.dx = self.x[1] - self.x[0]
         if dt is None:
-            dt = 0.2 * self.dx ** 2 / np.sqrt(D)
+            dt = 0.2 * self.dx**2 / np.sqrt(D)
         self.dt = dt
         self.T = T
         self.nt = int(T // dt)
@@ -487,11 +566,11 @@ class FlexuralBeamWave:
 
     def step(self) -> None:
         for i in range(2, self.Nx - 2):
-            w_xx = (self.w[i + 1] - 2 * self.w[i] + self.w[i - 1]) / self.dx ** 2
-            w_xx_plus = (self.w[i + 2] - 2 * self.w[i + 1] + self.w[i]) / self.dx ** 2
-            w_xx_minus = (self.w[i] - 2 * self.w[i - 1] + self.w[i - 2]) / self.dx ** 2
-            w_xxxx = (w_xx_plus - 2 * w_xx + w_xx_minus) / self.dx ** 2
-            self.w_new[i] = 2 * self.w[i] - self.w_old[i] - self.dt ** 2 * self.D * w_xxxx
+            w_xx = (self.w[i + 1] - 2 * self.w[i] + self.w[i - 1]) / self.dx**2
+            w_xx_plus = (self.w[i + 2] - 2 * self.w[i + 1] + self.w[i]) / self.dx**2
+            w_xx_minus = (self.w[i] - 2 * self.w[i - 1] + self.w[i - 2]) / self.dx**2
+            w_xxxx = (w_xx_plus - 2 * w_xx + w_xx_minus) / self.dx**2
+            self.w_new[i] = 2 * self.w[i] - self.w_old[i] - self.dt**2 * self.D * w_xxxx
         self.w_new[0] = 0.0
         self.w_new[1] = 0.0
         self.w_new[-1] = 0.0
@@ -512,7 +591,16 @@ class AlfvenWave:
     The update solves ``v_tt = v_A**2 * v_xx`` with Dirichlet boundaries.
     """
 
-    def __init__(self, B0: float = 1.0, rho: float = 1.0, mu0: float = 1.0, L: float = 2.0, Nx: int = 800, dt: Optional[float] = None, T: float = 2.0) -> None:
+    def __init__(
+        self,
+        B0: float = 1.0,
+        rho: float = 1.0,
+        mu0: float = 1.0,
+        L: float = 2.0,
+        Nx: int = 800,
+        dt: Optional[float] = None,
+        T: float = 2.0,
+    ) -> None:
         self.B0 = B0
         self.rho = rho
         self.mu0 = mu0
@@ -540,7 +628,8 @@ class AlfvenWave:
             self.v_new[i] = (
                 2 * self.v[i]
                 - self.v_old[i]
-                + (self.vA * self.dt / self.dx) ** 2 * (self.v[i + 1] - 2 * self.v[i] + self.v[i - 1])
+                + (self.vA * self.dt / self.dx) ** 2
+                * (self.v[i + 1] - 2 * self.v[i] + self.v[i - 1])
             )
         self.v_new[0] = 0.0
         self.v_new[-1] = 0.0


### PR DESCRIPTION
## Summary
- extend high quality solver with discrete signal and moving point sources
- add `get_colormap_lut` fallbacks for extra colormaps
- mention new modulators in README
- clean up unused imports and variables
- add small unit test covering simulator and LUTs

## Testing
- `ruff check .`
- `black --check examples/rossby_planetary_wave.py wave_sim/high_quality/__init__.py wave_sim/high_quality/runner.py wave_sim/high_quality/scene_objects.py wave_sim/high_quality/simulator.py wave_sim/high_quality/visualizer.py wave_sim/solvers.py tests/test_high_quality.py`
- `mypy tests/test_high_quality.py` *(fails: Cannot find implementation or library stub for module named 'numpy')*
- `PYTHONPATH=. pytest -q tests/test_high_quality.py` *(fails: ModuleNotFoundError: No module named 'numpy')*