### PR TITLE
Standardise 1‑D solvers and add dry‑run test

### DIFF
--- a/examples/alfven_wave.py
+++ b/examples/alfven_wave.py
@@ -16,7 +16,11 @@ def v0(x):
 DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
 
 
-def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="alfven_wave.mp4"):
+def generate_animation(
+    output_dir: str = DEFAULT_OUTPUT_DIR,
+    out_name: str = "alfven_wave.mp4",
+    steps: int | None = None,
+) -> str:
     os.makedirs(output_dir, exist_ok=True)
     out_path = os.path.join(output_dir, out_name)
 
@@ -30,7 +34,8 @@ def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="alfven_wave.mp4"
     sim.initial_conditions(v0)
     writer = imageio.get_writer(out_path, fps=30)
     fig, ax = plt.subplots(figsize=(8, 4))
-    for _ in range(sim.nt):
+    nsteps = sim.nt if steps is None else min(steps, sim.nt)
+    for _ in range(nsteps):
         sim.step()
         ax.clear()
         ax.plot(sim.x, sim.v)

--- a/examples/capillary_wave.py
+++ b/examples/capillary_wave.py
@@ -20,7 +20,11 @@ def deta0_dt(x):
 DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
 
 
-def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="capillary_wave.mp4"):
+def generate_animation(
+    output_dir: str = DEFAULT_OUTPUT_DIR,
+    out_name: str = "capillary_wave.mp4",
+    steps: int | None = None,
+) -> str:
     os.makedirs(output_dir, exist_ok=True)
     out_path = os.path.join(output_dir, out_name)
 
@@ -38,7 +42,8 @@ def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="capillary_wave.m
     writer = imageio.get_writer(out_path, fps=30)
     fig, ax = plt.subplots(figsize=(8, 4))
 
-    for i in range(sim.nt):
+    nsteps = sim.nt if steps is None else min(steps, sim.nt)
+    for i in range(nsteps):
         sim.step()
         ax.clear()
         ax.plot(sim.x, sim.eta_now)

--- a/examples/deep_water_gravity_wave.py
+++ b/examples/deep_water_gravity_wave.py
@@ -20,7 +20,11 @@ def deta0_dt(x):
 DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
 
 
-def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="deep_water_gravity_wave.mp4"):
+def generate_animation(
+    output_dir: str = DEFAULT_OUTPUT_DIR,
+    out_name: str = "deep_water_gravity_wave.mp4",
+    steps: int | None = None,
+) -> str:
     os.makedirs(output_dir, exist_ok=True)
     out_path = os.path.join(output_dir, out_name)
 
@@ -37,7 +41,8 @@ def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="deep_water_gravi
     writer = imageio.get_writer(out_path, fps=30)
     fig, ax = plt.subplots(figsize=(8, 4))
 
-    for i in range(sim.nt):
+    nsteps = sim.nt if steps is None else min(steps, sim.nt)
+    for i in range(nsteps):
         sim.step()
         ax.clear()
         ax.plot(sim.x, sim.eta_now)

--- a/examples/flexural_beam_wave.py
+++ b/examples/flexural_beam_wave.py
@@ -16,7 +16,11 @@ def w0(x):
 DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
 
 
-def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="flexural_beam_wave.mp4"):
+def generate_animation(
+    output_dir: str = DEFAULT_OUTPUT_DIR,
+    out_name: str = "flexural_beam_wave.mp4",
+    steps: int | None = None,
+) -> str:
     os.makedirs(output_dir, exist_ok=True)
     out_path = os.path.join(output_dir, out_name)
 
@@ -30,7 +34,8 @@ def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="flexural_beam_wa
     sim.initial_conditions(w0)
     writer = imageio.get_writer(out_path, fps=30)
     fig, ax = plt.subplots(figsize=(8, 4))
-    for _ in range(sim.nt):
+    nsteps = sim.nt if steps is None else min(steps, sim.nt)
+    for _ in range(nsteps):
         sim.step()
         ax.clear()
         ax.plot(sim.x, sim.w)

--- a/examples/internal_gravity_wave.py
+++ b/examples/internal_gravity_wave.py
@@ -15,7 +15,11 @@ def psi0(x):
 DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
 
 
-def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="internal_gravity_wave.mp4"):
+def generate_animation(
+    output_dir: str = DEFAULT_OUTPUT_DIR,
+    out_name: str = "internal_gravity_wave.mp4",
+    steps: int | None = None,
+) -> str:
     os.makedirs(output_dir, exist_ok=True)
     out_path = os.path.join(output_dir, out_name)
 
@@ -29,7 +33,8 @@ def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="internal_gravity
     sim.initial_conditions(psi0)
     writer = imageio.get_writer(out_path, fps=30)
     fig, ax = plt.subplots(figsize=(8, 4))
-    for _ in range(sim.nt):
+    nsteps = sim.nt if steps is None else min(steps, sim.nt)
+    for _ in range(nsteps):
         sim.step()
         ax.clear()
         ax.plot(sim.x, sim.psi)

--- a/examples/kelvin_wave.py
+++ b/examples/kelvin_wave.py
@@ -15,7 +15,11 @@ def eta0(y):
 DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
 
 
-def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="kelvin_wave.mp4"):
+def generate_animation(
+    output_dir: str = DEFAULT_OUTPUT_DIR,
+    out_name: str = "kelvin_wave.mp4",
+    steps: int | None = None,
+) -> str:
     os.makedirs(output_dir, exist_ok=True)
     out_path = os.path.join(output_dir, out_name)
 
@@ -29,7 +33,8 @@ def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="kelvin_wave.mp4"
     sim.initial_conditions(eta0)
     writer = imageio.get_writer(out_path, fps=30)
     fig, ax = plt.subplots(figsize=(8, 4))
-    for _ in range(sim.nt):
+    nsteps = sim.nt if steps is None else min(steps, sim.nt)
+    for _ in range(nsteps):
         sim.step()
         ax.clear()
         ax.plot(sim.y, sim.eta)

--- a/examples/plane_acoustic_wave.py
+++ b/examples/plane_acoustic_wave.py
@@ -19,7 +19,11 @@ def dp0_dt_initial(x):
 DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
 
 
-def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="plane_acoustic_wave.mp4"):
+def generate_animation(
+    output_dir: str = DEFAULT_OUTPUT_DIR,
+    out_name: str = "plane_acoustic_wave.mp4",
+    steps: int | None = None,
+) -> str:
     os.makedirs(output_dir, exist_ok=True)
     out_path = os.path.join(output_dir, out_name)
 
@@ -36,7 +40,8 @@ def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="plane_acoustic_w
     writer = imageio.get_writer(out_path, fps=30)
     fig, ax = plt.subplots(figsize=(8, 4))
 
-    for i in range(sim.nt):
+    nsteps = sim.nt if steps is None else min(steps, sim.nt)
+    for i in range(nsteps):
         sim.step()
         ax.clear()
         ax.plot(sim.x, sim.p_now)

--- a/examples/rossby_planetary_wave.py
+++ b/examples/rossby_planetary_wave.py
@@ -17,7 +17,11 @@ def psi0(X, Y):
 DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
 
 
-def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="rossby_planetary_wave.mp4"):
+def generate_animation(
+    output_dir: str = DEFAULT_OUTPUT_DIR,
+    out_name: str = "rossby_planetary_wave.mp4",
+    steps: int | None = None,
+) -> str:
     os.makedirs(output_dir, exist_ok=True)
     out_path = os.path.join(output_dir, out_name)
 
@@ -30,10 +34,11 @@ def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="rossby_planetary
     )
     writer = imageio.get_writer(out_path, fps=30)
     fig, ax = plt.subplots(figsize=(6, 5))
-    for _ in range(sim.nt):
+    nsteps = sim.nt if steps is None else min(steps, sim.nt)
+    for _ in range(nsteps):
         sim.step()
         ax.clear()
-        cf = ax.contourf(X, Y, sim.psi, levels=20, cmap="RdBu_r")
+        ax.contourf(X, Y, sim.psi, levels=20, cmap="RdBu_r")
         ax.set_xlabel("x")
         ax.set_ylabel("y")
         fig.canvas.draw()

--- a/examples/shallow_water_gravity_wave.py
+++ b/examples/shallow_water_gravity_wave.py
@@ -20,7 +20,11 @@ def u0(x):
 DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
 
 
-def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="shallow_water_gravity_wave.mp4"):
+def generate_animation(
+    output_dir: str = DEFAULT_OUTPUT_DIR,
+    out_name: str = "shallow_water_gravity_wave.mp4",
+    steps: int | None = None,
+) -> str:
     os.makedirs(output_dir, exist_ok=True)
     out_path = os.path.join(output_dir, out_name)
 
@@ -37,7 +41,8 @@ def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="shallow_water_gr
     writer = imageio.get_writer(out_path, fps=30)
     fig, ax = plt.subplots(figsize=(8, 4))
 
-    for i in range(sim.nt):
+    nsteps = sim.nt if steps is None else min(steps, sim.nt)
+    for i in range(nsteps):
         sim.step()
         ax.clear()
         ax.plot(sim.x, sim.Q[0, :])

--- a/examples/spherical_acoustic_wave.py
+++ b/examples/spherical_acoustic_wave.py
@@ -20,7 +20,11 @@ def dp0_dt_initial(r):
 DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
 
 
-def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="spherical_acoustic_wave.mp4"):
+def generate_animation(
+    output_dir: str = DEFAULT_OUTPUT_DIR,
+    out_name: str = "spherical_acoustic_wave.mp4",
+    steps: int | None = None,
+) -> str:
     os.makedirs(output_dir, exist_ok=True)
     out_path = os.path.join(output_dir, out_name)
 
@@ -37,7 +41,8 @@ def generate_animation(output_dir=DEFAULT_OUTPUT_DIR, out_name="spherical_acoust
     writer = imageio.get_writer(out_path, fps=30)
     fig, ax = plt.subplots(figsize=(8, 4))
 
-    for i in range(sim.nt):
+    nsteps = sim.nt if steps is None else min(steps, sim.nt)
+    for i in range(nsteps):
         sim.step()
         ax.clear()
         ax.plot(sim.r, sim.p_now)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,0 +1,39 @@
+import tempfile
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from examples.alfven_wave import generate_animation as gen_alfven
+from examples.flexural_beam_wave import generate_animation as gen_flexural
+from examples.internal_gravity_wave import generate_animation as gen_internal
+from examples.kelvin_wave import generate_animation as gen_kelvin
+from examples.rossby_planetary_wave import generate_animation as gen_rossby
+from examples.plane_acoustic_wave import generate_animation as gen_plane
+from examples.spherical_acoustic_wave import generate_animation as gen_spherical
+from examples.deep_water_gravity_wave import generate_animation as gen_deep
+from examples.shallow_water_gravity_wave import generate_animation as gen_shallow
+from examples.capillary_wave import generate_animation as gen_capillary
+
+GENERATORS = [
+    gen_alfven,
+    gen_flexural,
+    gen_internal,
+    gen_kelvin,
+    gen_rossby,
+    gen_plane,
+    gen_spherical,
+    gen_deep,
+    gen_shallow,
+    gen_capillary,
+]
+
+def test_generate_dry_run():
+    out_dir = tempfile.mkdtemp()
+    for gen in GENERATORS:
+        try:
+            path = gen(output_dir=out_dir, out_name="tmp.mp4", steps=2)
+        except Exception:
+            path = None
+        assert isinstance(path, str)
+        assert os.path.exists(out_dir)


### PR DESCRIPTION
## Summary
- add optional `steps` argument to all example `generate_animation` functions
- create `tests/test_generate.py` to exercise all generators in CI
- tidy up unused variable in `rossby_planetary_wave.py`

## Testing
- `ruff check examples tests`
- `flake8 examples` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*