### PR TITLE
Update README for wave simplifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,21 @@ The focus of this repository is purely on wave propagation. Earlier project
 notes about simulating elastic bodies via incremental potentials and Hessians
 are not implemented here.
 
-The repository provides **20** illustrative wave types.  Configurations for
-ten 2‑D phenomena (P, S and several surface/interface waves) are implemented in
-``wave_sim.wave_catalog`` for use with the GPU‑accelerated solver.  A further ten
-textbook waves are available via specialised one‑dimensional or spectral
-schemes in ``wave_sim.solvers``.  Surface and interface wave animations are
-**highly simplified**: they use a scalar wave model with preset speeds and do
-not capture the true dispersive or vector nature of these waves.
+The repository provides **20** illustrative wave types. Configurations for
+ten 2‑D phenomena (P, S, Rayleigh, Love, Lamb, Stoneley, Scholte waves) are implemented in
+``wave_sim.wave_catalog`` for use with the GPU‑accelerated ``WaveSimulator2D`` solver.
+A further ten textbook waves are available via specialised one‑dimensional or spectral
+schemes in ``wave_sim.solvers``.
+
+**Important Note on 2D Wave Fidelity:** The ``WaveSimulator2D`` is a generic scalar wave
+equation solver. While it reasonably models P-waves (compressional), its application to
+S-waves (shear) and particularly to complex phenomena like Rayleigh, Love, Lamb, Stoneley,
+and Scholte waves involves significant simplification. For these latter wave types, the
+simulations primarily demonstrate propagation at a pre-configured speed. They **do not**
+capture the true vector displacement fields, coupled P-SV motion, frequency-dependent
+dispersion, or the specific boundary conditions that give rise to these waves' unique
+characteristics. These examples are included for illustrative breadth rather than
+rigorous physical accuracy.
 
 Legacy modules under ``wave_sim2d`` have been removed.  Animations for the ten 2‑D wave phenomena from ``wave_sim.wave_catalog`` (e.g., P, S, Rayleigh waves) are generated using the GPU‑optimised utilities in ``wave_sim.high_quality``.
 These can fall back to NumPy if a CUDA device is not available.  The other ten 1‑D or spectral wave types (e.g., Alfven, Rossby waves) from ``wave_sim.solvers`` are animated using ``matplotlib`` directly within their respective example scripts.
@@ -25,7 +33,12 @@ sources. The boundary condition is specified with a
 
 * ``BoundaryCondition.REFLECTIVE`` – zero normal derivative at the edges
 * ``BoundaryCondition.PERIODIC`` – domain repeats at the edges
-* ``BoundaryCondition.ABSORBING`` – damped sponge layer near the borders
+* ``BoundaryCondition.ABSORBING`` – damped sponge layer near the borders, handled internally by the simulator
+
+Note: If ``BoundaryCondition.ABSORBING`` is active, the simulator applies its own
+sponge layer. For more customized absorption profiles, set the boundary to
+``BoundaryCondition.REFLECTIVE`` and add a ``StaticDampening`` scene object with
+a desired ``border_thickness`` and profile.
 
 The initial disturbance is passed via ``initial_field`` when creating a
 `WaveSimulator2D` or through the ``scene_builder`` used by
@@ -48,7 +61,10 @@ its strength over time. A ``GaussianBlobSource`` object creates a soft circular
 emitter using a Gaussian envelope.
 
 The solver emits a warning if the CFL condition ``c * dt / dx`` exceeds
-``1 / sqrt(2)`` to help maintain stability.
+``1 / sqrt(2)`` to help maintain stability. The spatial step ``dx`` and time step ``dt``
+for `WaveSimulator2D` default to `1.0`. These values define the simulation's
+discretization and directly affect the interpretation of wave speeds (``c``) and source
+frequencies. Ensure these are consistent with your desired physical scales.
 
 For the specialised shear-wave configurations ``SHWave`` and ``SVWave`` the
 physical displacement can be retrieved from simulation frames via helper


### PR DESCRIPTION
## Summary
- clarify limitations of 2D surface and interface waves
- document default `dx` and `dt` values and their effect
- explain how absorbing boundaries interact with `StaticDampening`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*