### PR TITLE
Port old MovingCharge object and clarify wave placeholders

### DIFF
--- a/wave_sim/high_quality/__init__.py
+++ b/wave_sim/high_quality/__init__.py
@@ -14,6 +14,7 @@ from .scene_objects import (
     LineSource,
     ModulatorSmoothSquare,
     ModulatorDiscreteSignal,
+    MovingCharge,
 )
 
 __all__ = [
@@ -32,4 +33,5 @@ __all__ = [
     "LineSource",
     "ModulatorSmoothSquare",
     "ModulatorDiscreteSignal",
+    "MovingCharge",
 ]

--- a/wave_sim/high_quality/scene_objects.py
+++ b/wave_sim/high_quality/scene_objects.py
@@ -321,4 +321,52 @@ class ModulatorDiscreteSignal:
         return (1.0 - frac) * s0 + frac * s1
 
 
+def gaussian_kernel(size, sigma):
+    ax = np.linspace(-(size-1)/2., (size-1)/2., size)
+    gauss = np.exp(-0.5 * ax**2 / sigma**2)
+    kernel = np.outer(gauss, gauss)
+    return kernel / kernel.sum()
+
+
+class MovingCharge(SceneObject):
+    """Demo object that writes a small travelling Gaussian blob."""
+
+    def __init__(self, x, y, freq, amplitude):
+        self.x = x
+        self.y = y
+        self.freq = freq
+        self.amplitude = amplitude
+        self.size = 11
+        host_kernel = gaussian_kernel(self.size, sigma=self.size/3.0)
+        xp = cp if cp and XP is cp else np
+        self.kernel = xp.array(host_kernel, dtype=xp.float32)
+
+    def render(self, field, wave_speed_field, dampening_field):
+        pass
+
+    def update_field(self, field, t):
+        xp = cp if cp and isinstance(field, cp.ndarray) else np
+        fade_in = math.sin(min(t*0.1, math.pi/2))
+
+        x_now = int(self.x + math.sin(self.freq * t*0.05)*200)
+        y_now = int(self.y + math.sin(self.freq * t)*self.amplitude)
+
+        half = self.size // 2
+        y0 = max(y_now-half, 0)
+        y1 = min(y_now+half+1, field.shape[0])
+        x0 = max(x_now-half, 0)
+        x1 = min(x_now+half+1, field.shape[1])
+
+        ky0 = half - (y_now - y0)
+        kx0 = half - (x_now - x0)
+        ky1 = ky0 + (y1 - y0)
+        kx1 = kx0 + (x1 - x0)
+
+        if (y1>y0) and (x1>x0):
+            patch = field[y0:y1, x0:x1]
+            k = self.kernel[ky0:ky1, kx0:kx1]
+            patch += fade_in * 0.25 * k
+            field[y0:y1, x0:x1] = patch
+
+
 

--- a/wave_sim/wave_catalog.py
+++ b/wave_sim/wave_catalog.py
@@ -96,7 +96,7 @@ class SVWave(Wave2DConfig):
 
 
 class RayleighWave(Wave2DConfig):
-    """Rayleigh surface wave – scalar surrogate with realistic c_R."""
+    """NOTE: placeholder using the scalar wave equation with ``c`` ≈ 1300 m/s."""
 
     def __init__(self, **kw):
         c_R = rayleigh_wave_speed(_ALPHA, _BETA)
@@ -104,7 +104,7 @@ class RayleighWave(Wave2DConfig):
 
 
 class LoveWave(Wave2DConfig):
-    """Love surface wave – fundamental mode phase speed (~10 Hz)."""
+    """NOTE: placeholder; scalar wave with speed from the Love-mode estimate."""
 
     def __init__(self, h: float = 100.0, **kw):
         c_L = love_wave_dispersion(freq=2*np.pi*10,
@@ -114,7 +114,7 @@ class LoveWave(Wave2DConfig):
 
 
 class LambS0Mode(Wave2DConfig):
-    """Symmetric Lamb plate mode – scalar surrogate."""
+    """NOTE: placeholder; scalar wave with speed from Lamb S0 estimate."""
 
     def __init__(self, plate_h: float = 5.0, **kw):
         c = lamb_s0_mode(freq=2*np.pi*5, alpha=_ALPHA, beta=_BETA,
@@ -123,7 +123,7 @@ class LambS0Mode(Wave2DConfig):
 
 
 class LambA0Mode(Wave2DConfig):
-    """Antisymmetric Lamb plate mode."""
+    """NOTE: placeholder; scalar wave with speed from Lamb A0 estimate."""
 
     def __init__(self, plate_h: float = 5.0, **kw):
         c = lamb_a0_mode(freq=2*np.pi*5, alpha=_ALPHA, beta=_BETA,
@@ -132,7 +132,7 @@ class LambA0Mode(Wave2DConfig):
 
 
 class StoneleyWave(Wave2DConfig):
-    """Stoneley solid–solid interface – scalar surrogate."""
+    """NOTE: placeholder; scalar wave with speed from Stoneley estimate."""
 
     def __init__(self, **kw):
         c = stoneley_wave_speed(_ALPHA, _BETA, _RHO,
@@ -141,7 +141,7 @@ class StoneleyWave(Wave2DConfig):
 
 
 class ScholteWave(Wave2DConfig):
-    """Scholte solid–fluid interface – scalar surrogate."""
+    """NOTE: placeholder; scalar wave with speed from Scholte estimate."""
 
     def __init__(self, **kw):
         c = scholte_wave_speed(_ALPHA, _BETA, _RHO,


### PR DESCRIPTION
## Summary
- add `MovingCharge` demo object to the high-quality scene objects
- expose `MovingCharge` from the high-quality package
- clarify that Rayleigh, Love, Lamb, Stoneley and Scholte configurations are placeholders

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy/matplotlib)*