### PR TITLE
Add standard 1D animation utility and refactor examples

### DIFF
--- a/examples/alfven_wave.py
+++ b/examples/alfven_wave.py
@@ -1,11 +1,9 @@
 """Alfv\u00e9n wave example using the consolidated solver."""
 
-import matplotlib.pyplot as plt
 import numpy as np
-import imageio.v2 as imageio
-import os
 
 from wave_sim import AlfvenWave
+from wave_sim.animation_utils import generate_1d_animation, DEFAULT_OUTPUT_DIR_1D
 
 
 def v0(x):
@@ -13,7 +11,7 @@ def v0(x):
     return np.sin(2 * np.pi * x / L)
 
 
-DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
+DEFAULT_OUTPUT_DIR = DEFAULT_OUTPUT_DIR_1D
 
 
 def generate_animation(
@@ -21,9 +19,6 @@ def generate_animation(
     out_name: str = "alfven_wave.mp4",
     steps: int | None = None,
 ) -> str:
-    os.makedirs(output_dir, exist_ok=True)
-    out_path = os.path.join(output_dir, out_name)
-
     sim_L = 2.0
     sim_Nx = 800
     sim_T = 2.0
@@ -32,21 +27,17 @@ def generate_animation(
     dt_val = 0.5 * dx / vA_sim
     sim = AlfvenWave(L=sim_L, Nx=sim_Nx, T=sim_T, dt=dt_val)
     sim.initial_conditions(v0)
-    writer = imageio.get_writer(out_path, fps=30)
-    fig, ax = plt.subplots(figsize=(8, 4))
-    nsteps = sim.nt if steps is None else min(steps, sim.nt)
-    for _ in range(nsteps):
-        sim.step()
-        ax.clear()
-        ax.plot(sim.x, sim.v)
-        ax.set_ylim(-1.2, 1.2)
-        fig.canvas.draw()
-        img = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
-        img = img.reshape(fig.canvas.get_width_height()[::-1] + (3,))
-        writer.append_data(img)
-    writer.close()
-    plt.close(fig)
-    return out_path
+
+    return generate_1d_animation(
+        solver=sim,
+        out_name=out_name,
+        plot_variable_name="v",
+        title_prefix="Alfvén Wave",
+        y_label="Velocity v(x,t)",
+        output_dir=output_dir,
+        y_lims=(-1.2, 1.2),
+        total_steps=steps,
+    )
 
 
 if __name__ == "__main__":

--- a/examples/deep_water_gravity_wave.py
+++ b/examples/deep_water_gravity_wave.py
@@ -1,11 +1,9 @@
 """Deep water gravity wave example using the consolidated solver."""
 
-import matplotlib.pyplot as plt
 import numpy as np
-import imageio.v2 as imageio
-import os
 
 from wave_sim import DeepWaterGravityWave
+from wave_sim.animation_utils import generate_1d_animation, DEFAULT_OUTPUT_DIR_1D
 from wave_sim.initial_conditions import gaussian_1d
 
 
@@ -17,7 +15,7 @@ def eta0(x):
 def deta0_dt(x):
     return np.zeros_like(x)
 
-DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
+DEFAULT_OUTPUT_DIR = DEFAULT_OUTPUT_DIR_1D
 
 
 def generate_animation(
@@ -25,9 +23,6 @@ def generate_animation(
     out_name: str = "deep_water_gravity_wave.mp4",
     steps: int | None = None,
 ) -> str:
-    os.makedirs(output_dir, exist_ok=True)
-    out_path = os.path.join(output_dir, out_name)
-
     L_domain = 2 * np.pi
     Nx_points = 256
     T_duration = 2.0
@@ -38,27 +33,16 @@ def generate_animation(
     sim = DeepWaterGravityWave(L=L_domain, Nx=Nx_points, g=g_val, dt=dt_val, T=T_duration)
     sim.initial_conditions(eta0, deta0_dt)
 
-    writer = imageio.get_writer(out_path, fps=30)
-    fig, ax = plt.subplots(figsize=(8, 4))
-
-    nsteps = sim.nt if steps is None else min(steps, sim.nt)
-    for i in range(nsteps):
-        sim.step()
-        ax.clear()
-        ax.plot(sim.x, sim.eta_now)
-        ax.set_ylim(-1.2, 1.2)
-        ax.set_xlabel("x")
-        ax.set_ylabel("Surface elevation")
-        ax.set_title(f"Deep Water Gravity Wave, Time: {i*sim.dt:.3f}s")
-        fig.canvas.draw()
-        img = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
-        img = img.reshape(fig.canvas.get_width_height()[::-1] + (3,))
-        writer.append_data(img)
-
-    writer.close()
-    plt.close(fig)
-    print(f"Generated 1D animation: {out_path}")
-    return out_path
+    return generate_1d_animation(
+        solver=sim,
+        out_name=out_name,
+        plot_variable_name="eta_now",
+        title_prefix="Deep Water Gravity Wave",
+        y_label="Surface elevation",
+        output_dir=output_dir,
+        y_lims=(-1.2, 1.2),
+        total_steps=steps,
+    )
 
 
 if __name__ == "__main__":

--- a/examples/flexural_beam_wave.py
+++ b/examples/flexural_beam_wave.py
@@ -1,11 +1,9 @@
 """Flexural beam wave solved with the consolidated solver."""
 
-import matplotlib.pyplot as plt
 import numpy as np
-import imageio.v2 as imageio
-import os
 
 from wave_sim import FlexuralBeamWave
+from wave_sim.animation_utils import generate_1d_animation, DEFAULT_OUTPUT_DIR_1D
 
 
 def w0(x):
@@ -13,7 +11,7 @@ def w0(x):
     return np.exp(-100 * (x - L / 2) ** 2)
 
 
-DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
+DEFAULT_OUTPUT_DIR = DEFAULT_OUTPUT_DIR_1D
 
 
 def generate_animation(
@@ -21,9 +19,6 @@ def generate_animation(
     out_name: str = "flexural_beam_wave.mp4",
     steps: int | None = None,
 ) -> str:
-    os.makedirs(output_dir, exist_ok=True)
-    out_path = os.path.join(output_dir, out_name)
-
     sim_L = 2.0
     sim_Nx = 801
     sim_T = 5.0
@@ -32,21 +27,17 @@ def generate_animation(
     dt_val = 0.2 * dx ** 2 / np.sqrt(D_val)
     sim = FlexuralBeamWave(D=D_val, L=sim_L, Nx=sim_Nx, T=sim_T, dt=dt_val)
     sim.initial_conditions(w0)
-    writer = imageio.get_writer(out_path, fps=30)
-    fig, ax = plt.subplots(figsize=(8, 4))
-    nsteps = sim.nt if steps is None else min(steps, sim.nt)
-    for _ in range(nsteps):
-        sim.step()
-        ax.clear()
-        ax.plot(sim.x, sim.w)
-        ax.set_ylim(-1.1, 1.1)
-        fig.canvas.draw()
-        img = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
-        img = img.reshape(fig.canvas.get_width_height()[::-1] + (3,))
-        writer.append_data(img)
-    writer.close()
-    plt.close(fig)
-    return out_path
+
+    return generate_1d_animation(
+        solver=sim,
+        out_name=out_name,
+        plot_variable_name="w",
+        title_prefix="Flexural Beam Wave",
+        y_label="Displacement w(x,t)",
+        output_dir=output_dir,
+        y_lims=(-1.1, 1.1),
+        total_steps=steps,
+    )
 
 
 if __name__ == "__main__":

--- a/examples/internal_gravity_wave.py
+++ b/examples/internal_gravity_wave.py
@@ -1,18 +1,16 @@
 """1-D internal gravity wave using the consolidated solver."""
 
-import matplotlib.pyplot as plt
 import numpy as np
-import imageio.v2 as imageio
-import os
 
 from wave_sim import InternalGravityWave
+from wave_sim.animation_utils import generate_1d_animation, DEFAULT_OUTPUT_DIR_1D
 
 
 def psi0(x):
     return np.exp(-100 * (x - 1.0) ** 2)
 
 
-DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
+DEFAULT_OUTPUT_DIR = DEFAULT_OUTPUT_DIR_1D
 
 
 def generate_animation(
@@ -20,9 +18,6 @@ def generate_animation(
     out_name: str = "internal_gravity_wave.mp4",
     steps: int | None = None,
 ) -> str:
-    os.makedirs(output_dir, exist_ok=True)
-    out_path = os.path.join(output_dir, out_name)
-
     sim_L = 2.0
     sim_Nx = 800
     sim_T = 3.0
@@ -31,21 +26,17 @@ def generate_animation(
     dt_val = 0.8 * dx / N_val
     sim = InternalGravityWave(L=sim_L, Nx=sim_Nx, T=sim_T, dt=dt_val)
     sim.initial_conditions(psi0)
-    writer = imageio.get_writer(out_path, fps=30)
-    fig, ax = plt.subplots(figsize=(8, 4))
-    nsteps = sim.nt if steps is None else min(steps, sim.nt)
-    for _ in range(nsteps):
-        sim.step()
-        ax.clear()
-        ax.plot(sim.x, sim.psi)
-        ax.set_ylim(-1.1, 1.1)
-        fig.canvas.draw()
-        img = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
-        img = img.reshape(fig.canvas.get_width_height()[::-1] + (3,))
-        writer.append_data(img)
-    writer.close()
-    plt.close(fig)
-    return out_path
+
+    return generate_1d_animation(
+        solver=sim,
+        out_name=out_name,
+        plot_variable_name="psi",
+        title_prefix="Internal Gravity Wave",
+        y_label="Streamfunction ψ(x,t)",
+        output_dir=output_dir,
+        y_lims=(-1.1, 1.1),
+        total_steps=steps,
+    )
 
 
 if __name__ == "__main__":

--- a/examples/kelvin_wave.py
+++ b/examples/kelvin_wave.py
@@ -1,18 +1,16 @@
 """Rotating shallow water Kelvin wave using the unified solver."""
 
-import matplotlib.pyplot as plt
 import numpy as np
-import imageio.v2 as imageio
-import os
 
 from wave_sim import KelvinWave
+from wave_sim.animation_utils import generate_1d_animation, DEFAULT_OUTPUT_DIR_1D
 
 
 def eta0(y):
     return np.exp(-((y - 2.5) / 0.5) ** 2)
 
 
-DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
+DEFAULT_OUTPUT_DIR = DEFAULT_OUTPUT_DIR_1D
 
 
 def generate_animation(
@@ -20,9 +18,6 @@ def generate_animation(
     out_name: str = "kelvin_wave.mp4",
     steps: int | None = None,
 ) -> str:
-    os.makedirs(output_dir, exist_ok=True)
-    out_path = os.path.join(output_dir, out_name)
-
     sim_L = 10.0
     sim_Ny = 800
     sim_T = 10.0
@@ -31,21 +26,18 @@ def generate_animation(
     dt_val = 0.4 * dy / c
     sim = KelvinWave(L=sim_L, Ny=sim_Ny, T=sim_T, dt=dt_val)
     sim.initial_conditions(eta0)
-    writer = imageio.get_writer(out_path, fps=30)
-    fig, ax = plt.subplots(figsize=(8, 4))
-    nsteps = sim.nt if steps is None else min(steps, sim.nt)
-    for _ in range(nsteps):
-        sim.step()
-        ax.clear()
-        ax.plot(sim.y, sim.eta)
-        ax.set_ylim(-1.1, 1.1)
-        fig.canvas.draw()
-        img = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
-        img = img.reshape(fig.canvas.get_width_height()[::-1] + (3,))
-        writer.append_data(img)
-    writer.close()
-    plt.close(fig)
-    return out_path
+
+    return generate_1d_animation(
+        solver=sim,
+        out_name=out_name,
+        plot_variable_name="eta",
+        title_prefix="Kelvin Wave",
+        y_label="Surface displacement",
+        output_dir=output_dir,
+        y_lims=(-1.1, 1.1),
+        x_label="y",
+        total_steps=steps,
+    )
 
 
 if __name__ == "__main__":

--- a/examples/plane_acoustic_wave.py
+++ b/examples/plane_acoustic_wave.py
@@ -1,11 +1,9 @@
 """Plane acoustic wave example using the consolidated solver."""
 
-import matplotlib.pyplot as plt
 import numpy as np
-import imageio.v2 as imageio
-import os
 
 from wave_sim import PlaneAcousticWave
+from wave_sim.animation_utils import generate_1d_animation, DEFAULT_OUTPUT_DIR_1D
 from wave_sim.initial_conditions import gaussian_1d
 
 
@@ -16,7 +14,7 @@ def p0_initial(x):
 def dp0_dt_initial(x):
     return np.zeros_like(x)
 
-DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
+DEFAULT_OUTPUT_DIR = DEFAULT_OUTPUT_DIR_1D
 
 
 def generate_animation(
@@ -24,9 +22,6 @@ def generate_animation(
     out_name: str = "plane_acoustic_wave.mp4",
     steps: int | None = None,
 ) -> str:
-    os.makedirs(output_dir, exist_ok=True)
-    out_path = os.path.join(output_dir, out_name)
-
     L_domain = 1.0
     Nx_points = 400
     T_duration = 2.0
@@ -37,27 +32,16 @@ def generate_animation(
     sim = PlaneAcousticWave(c=c_speed, L=L_domain, Nx=Nx_points, dt=dt_val, T=T_duration)
     sim.initial_conditions(p0_initial, dp_init_func=dp0_dt_initial)
 
-    writer = imageio.get_writer(out_path, fps=30)
-    fig, ax = plt.subplots(figsize=(8, 4))
-
-    nsteps = sim.nt if steps is None else min(steps, sim.nt)
-    for i in range(nsteps):
-        sim.step()
-        ax.clear()
-        ax.plot(sim.x, sim.p_now)
-        ax.set_ylim(-1.2, 1.2)
-        ax.set_xlabel("x")
-        ax.set_ylabel("Pressure p(x,t)")
-        ax.set_title(f"Plane Acoustic Wave, Time: {i*sim.dt:.3f}s")
-        fig.canvas.draw()
-        img = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
-        img = img.reshape(fig.canvas.get_width_height()[::-1] + (3,))
-        writer.append_data(img)
-
-    writer.close()
-    plt.close(fig)
-    print(f"Generated 1D animation: {out_path}")
-    return out_path
+    return generate_1d_animation(
+        solver=sim,
+        out_name=out_name,
+        plot_variable_name="p_now",
+        title_prefix="Plane Acoustic Wave",
+        y_label="Pressure p(x,t)",
+        output_dir=output_dir,
+        y_lims=(-1.2, 1.2),
+        total_steps=steps,
+    )
 
 
 if __name__ == "__main__":

--- a/examples/rossby_planetary_wave.py
+++ b/examples/rossby_planetary_wave.py
@@ -34,13 +34,18 @@ def generate_animation(
     )
     writer = imageio.get_writer(out_path, fps=30)
     fig, ax = plt.subplots(figsize=(6, 5))
+    cbar = None
     nsteps = sim.nt if steps is None else min(steps, sim.nt)
-    for _ in range(nsteps):
+    for step_num in range(nsteps):
         sim.step()
         ax.clear()
-        ax.contourf(X, Y, sim.psi, levels=20, cmap="RdBu_r")
+        m = ax.contourf(X, Y, sim.psi, levels=20, cmap="RdBu_r")
+        if cbar is None:
+            cbar = fig.colorbar(m, ax=ax)
+        current_time = sim.t if hasattr(sim, "t") else (step_num + 1) * sim.dt
         ax.set_xlabel("x")
         ax.set_ylabel("y")
+        ax.set_title(f"Rossby Planetary Wave, Time: {current_time:.3f}s")
         fig.canvas.draw()
         img = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
         img = img.reshape(fig.canvas.get_width_height()[::-1] + (3,))

--- a/examples/shallow_water_gravity_wave.py
+++ b/examples/shallow_water_gravity_wave.py
@@ -1,11 +1,9 @@
 """Shallow water gravity wave example using the consolidated solver."""
 
-import matplotlib.pyplot as plt
 import numpy as np
-import imageio.v2 as imageio
-import os
 
 from wave_sim import ShallowWaterGravityWave
+from wave_sim.animation_utils import generate_1d_animation, DEFAULT_OUTPUT_DIR_1D
 from wave_sim.initial_conditions import gaussian_1d
 
 
@@ -17,7 +15,7 @@ def h0(x):
 def u0(x):
     return np.zeros_like(x)
 
-DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
+DEFAULT_OUTPUT_DIR = DEFAULT_OUTPUT_DIR_1D
 
 
 def generate_animation(
@@ -25,9 +23,6 @@ def generate_animation(
     out_name: str = "shallow_water_gravity_wave.mp4",
     steps: int | None = None,
 ) -> str:
-    os.makedirs(output_dir, exist_ok=True)
-    out_path = os.path.join(output_dir, out_name)
-
     L_domain = 10.0
     Nx_points = 200
     T_duration = 2.0
@@ -38,27 +33,16 @@ def generate_animation(
     sim = ShallowWaterGravityWave(g=g_val, L=L_domain, Nx=Nx_points, dt=dt_val, T=T_duration)
     sim.initial_conditions(h0, u0)
 
-    writer = imageio.get_writer(out_path, fps=30)
-    fig, ax = plt.subplots(figsize=(8, 4))
-
-    nsteps = sim.nt if steps is None else min(steps, sim.nt)
-    for i in range(nsteps):
-        sim.step()
-        ax.clear()
-        ax.plot(sim.x, sim.Q[0, :])
-        ax.set_ylim(0.8, 1.2)
-        ax.set_xlabel("x")
-        ax.set_ylabel("Water height")
-        ax.set_title(f"Shallow Water Gravity Wave, Time: {i*sim.dt:.3f}s")
-        fig.canvas.draw()
-        img = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
-        img = img.reshape(fig.canvas.get_width_height()[::-1] + (3,))
-        writer.append_data(img)
-
-    writer.close()
-    plt.close(fig)
-    print(f"Generated 1D animation: {out_path}")
-    return out_path
+    return generate_1d_animation(
+        solver=sim,
+        out_name=out_name,
+        plot_variable_name="Q",
+        title_prefix="Shallow Water Gravity Wave",
+        y_label="Water height",
+        output_dir=output_dir,
+        y_lims=(0.8, 1.2),
+        total_steps=steps,
+    )
 
 
 if __name__ == "__main__":

--- a/examples/spherical_acoustic_wave.py
+++ b/examples/spherical_acoustic_wave.py
@@ -1,11 +1,9 @@
 """Spherical acoustic wave example using the consolidated solver."""
 
-import matplotlib.pyplot as plt
 import numpy as np
-import imageio.v2 as imageio
-import os
 
 from wave_sim import SphericalAcousticWave
+from wave_sim.animation_utils import generate_1d_animation, DEFAULT_OUTPUT_DIR_1D
 from wave_sim.initial_conditions import gaussian_1d
 
 
@@ -17,7 +15,7 @@ def p0_initial(r):
 def dp0_dt_initial(r):
     return np.zeros_like(r)
 
-DEFAULT_OUTPUT_DIR = "output_1d_animations_individual"
+DEFAULT_OUTPUT_DIR = DEFAULT_OUTPUT_DIR_1D
 
 
 def generate_animation(
@@ -25,9 +23,6 @@ def generate_animation(
     out_name: str = "spherical_acoustic_wave.mp4",
     steps: int | None = None,
 ) -> str:
-    os.makedirs(output_dir, exist_ok=True)
-    out_path = os.path.join(output_dir, out_name)
-
     R_domain = 2.0
     Nr_points = 400
     T_duration = 2.0
@@ -38,27 +33,17 @@ def generate_animation(
     sim = SphericalAcousticWave(c=c_speed, R=R_domain, Nr=Nr_points, dt=dt_val, T=T_duration)
     sim.initial_conditions(p0_initial, dp_init_func=dp0_dt_initial)
 
-    writer = imageio.get_writer(out_path, fps=30)
-    fig, ax = plt.subplots(figsize=(8, 4))
-
-    nsteps = sim.nt if steps is None else min(steps, sim.nt)
-    for i in range(nsteps):
-        sim.step()
-        ax.clear()
-        ax.plot(sim.r, sim.p_now)
-        ax.set_ylim(-1.2, 1.2)
-        ax.set_xlabel("r")
-        ax.set_ylabel("Pressure p(r,t)")
-        ax.set_title(f"Spherical Acoustic Wave, Time: {i*sim.dt:.3f}s")
-        fig.canvas.draw()
-        img = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
-        img = img.reshape(fig.canvas.get_width_height()[::-1] + (3,))
-        writer.append_data(img)
-
-    writer.close()
-    plt.close(fig)
-    print(f"Generated 1D animation: {out_path}")
-    return out_path
+    return generate_1d_animation(
+        solver=sim,
+        out_name=out_name,
+        plot_variable_name="p_now",
+        title_prefix="Spherical Acoustic Wave",
+        y_label="Pressure p(r,t)",
+        output_dir=output_dir,
+        y_lims=(-1.2, 1.2),
+        x_label="r",
+        total_steps=steps,
+    )
 
 
 if __name__ == "__main__":

--- a/wave_sim/__init__.py
+++ b/wave_sim/__init__.py
@@ -57,6 +57,7 @@ from .dispersion import (
     scholte_wave_speed,
 )
 from .collage import collage_videos
+from .animation_utils import generate_1d_animation, DEFAULT_OUTPUT_DIR_1D
 
 __all__ = [
     "WaveSimulator2D",
@@ -109,4 +110,6 @@ __all__ = [
     "stoneley_wave_speed",
     "scholte_wave_speed",
     "collage_videos",
+    "generate_1d_animation",
+    "DEFAULT_OUTPUT_DIR_1D",
 ]

--- a/wave_sim/animation_utils.py
+++ b/wave_sim/animation_utils.py
@@ -1,0 +1,66 @@
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+import imageio.v2 as imageio
+
+DEFAULT_OUTPUT_DIR_1D = "output_1d_animations_individual"
+
+def generate_1d_animation(
+    solver,
+    out_name: str,
+    plot_variable_name: str,
+    title_prefix: str,
+    y_label: str,
+    output_dir: str = DEFAULT_OUTPUT_DIR_1D,
+    x_label: str = "Position",
+    y_lims: tuple | None = None,
+    fps: int = 30,
+    total_steps: int | None = None,
+    figure_size: tuple = (8, 4),
+) -> str:
+    """Generate a simple 1-D matplotlib animation from a solver."""
+    os.makedirs(output_dir, exist_ok=True)
+    out_path = os.path.join(output_dir, out_name)
+
+    writer = imageio.get_writer(out_path, fps=fps)
+    fig, ax = plt.subplots(figsize=figure_size)
+
+    if hasattr(solver, "x"):
+        coords = solver.x
+    elif hasattr(solver, "r"):
+        coords = solver.r
+    elif hasattr(solver, "y"):
+        coords = solver.y
+    else:
+        raise AttributeError("Solver does not provide spatial coordinates")
+
+    nsteps = getattr(solver, "nt", None)
+    if nsteps is None:
+        if hasattr(solver, "T") and hasattr(solver, "dt"):
+            nsteps = int(solver.T / solver.dt)
+        else:
+            nsteps = 0
+    if total_steps is not None:
+        nsteps = min(total_steps, nsteps)
+
+    for step in range(nsteps):
+        solver.step()
+        current_time = getattr(solver, "t", (step + 1) * solver.dt)
+        ax.clear()
+        data = getattr(solver, plot_variable_name)
+        if isinstance(data, np.ndarray) and data.ndim > 1:
+            data = data[0]
+        ax.plot(coords, data)
+        if y_lims is not None:
+            ax.set_ylim(*y_lims)
+        ax.set_xlabel(x_label)
+        ax.set_ylabel(y_label)
+        ax.set_title(f"{title_prefix}, Time: {current_time:.3f}s")
+        fig.canvas.draw()
+        img = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
+        img = img.reshape(fig.canvas.get_width_height()[::-1] + (3,))
+        writer.append_data(img)
+
+    writer.close()
+    plt.close(fig)
+    return out_path


### PR DESCRIPTION
## Summary
- create `animation_utils.generate_1d_animation`
- expose the utility in `wave_sim.__init__`
- refactor 1D example scripts to use the new function
- polish Rossby planetary wave example titles and colorbar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*