### PR TITLE
Enable GPU-backed color LUTs

### DIFF
--- a/wave_sim/high_quality/runner.py
+++ b/wave_sim/high_quality/runner.py
@@ -40,8 +40,8 @@ def simulate_wave(
     )
     sim.global_dampening = global_dampening
     vis = WaveVisualizer(
-        field_colormap=get_colormap_lut("wave1"),
-        intensity_colormap=get_colormap_lut("afmhot"),
+        field_colormap=get_colormap_lut("wave1", backend=backend),
+        intensity_colormap=get_colormap_lut("afmhot", backend=backend),
     )
     writer = imageio.get_writer(out_path, fps=fps)
     for i in range(steps):


### PR DESCRIPTION
## Summary
- support GPU LUTs by passing backend to `get_colormap_lut`
- leave images on the GPU until writing when possible
- create visualization LUTs with the same backend as the simulator

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*