### PR TITLE
Add static scene optimization and API

### DIFF
--- a/tests/test_scene_objects.py
+++ b/tests/test_scene_objects.py
@@ -17,6 +17,7 @@ from wave_sim.high_quality.scene_objects import (
     ModulatorSmoothSquare,
     ModulatorDiscreteSignal,
 )
+from wave_sim.high_quality.simulator import WaveSimulator2D, SceneObject
 
 
 def test_point_source_phase_and_modulator():
@@ -43,4 +44,43 @@ def test_modulator_discrete_signal_interp():
     m = ModulatorDiscreteSignal([0, 1, 2], [0, 1, 0])
     assert m(0.5) == pytest.approx(0.5)
     assert m(1.5) == pytest.approx(0.5)
+
+
+class DummyStatic(SceneObject):
+    def __init__(self):
+        self.count = 0
+
+    def render(self, field, c, d):
+        self.count += 1
+
+    def update_field(self, field, t):
+        pass
+
+
+class DummyDynamic(DummyStatic):
+    is_static = False
+
+
+def test_wave_simulator_static_scene_skip_render():
+    obj = DummyStatic()
+    sim = WaveSimulator2D(8, 8, [obj], backend="cpu")
+    assert obj.count == 1
+    sim.update_scene()
+    assert obj.count == 1
+
+
+def test_wave_simulator_mark_dirty():
+    obj = DummyStatic()
+    sim = WaveSimulator2D(8, 8, [obj], backend="cpu")
+    sim.mark_scene_dirty()
+    sim.update_scene()
+    assert obj.count == 2
+
+
+def test_wave_simulator_dynamic_object_always_render():
+    obj = DummyDynamic()
+    sim = WaveSimulator2D(8, 8, [obj], backend="cpu")
+    assert obj.count == 1
+    sim.update_scene()
+    assert obj.count == 2
 

--- a/wave_sim/high_quality/scene_objects.py
+++ b/wave_sim/high_quality/scene_objects.py
@@ -157,6 +157,9 @@ class StaticImageScene(SceneObject):
 class StrainRefractiveIndex(SceneObject):
     """Refractive index field coupled to local strain."""
 
+    # requires recomputation every frame because it depends on the current field
+    is_static = False
+
     def __init__(self, refractive_index_offset, coupling_constant):
         self.coupling_constant = coupling_constant
         self.refractive_index_offset = refractive_index_offset


### PR DESCRIPTION
## Summary
- add `is_static` flag to `SceneObject`
- skip scene re-render in `WaveSimulator2D` when all objects are static
- expose `mark_scene_dirty` API to force re-render
- mark `StrainRefractiveIndex` dynamic
- add tests for new behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*