### PR TITLE
Implement cp.pad Laplacian

### DIFF
--- a/examples/laplacian_benchmark.py
+++ b/examples/laplacian_benchmark.py
@@ -1,0 +1,60 @@
+"""Benchmark Laplacian implementations.
+
+This script compares the previous ``convolve2d`` based Laplacian with the
+finite-difference version implemented using :func:`cp.pad`/`np.pad` and
+``cp.roll``.
+"""
+
+import time
+import numpy as np
+
+try:
+    import cupy as cp
+    import cupyx.scipy.signal as cusig
+except Exception:  # pragma: no cover - optional dependency
+    cp = None  # type: ignore
+    cusig = None  # type: ignore
+
+import scipy.signal as sig
+
+from wave_sim.core.kernels import get_laplacian_kernel, finite_difference_laplacian
+
+
+def _time_fn(fn, arr, steps=50):
+    start = time.perf_counter()
+    for _ in range(steps):
+        fn(arr)
+    return time.perf_counter() - start
+
+
+def benchmark(n=512, steps=50, backend="gpu"):
+    xp = cp if backend == "gpu" and cp is not None else np
+    arr = xp.random.random((n, n)).astype(xp.float32)
+    kernel = get_laplacian_kernel(xp)
+
+    if xp is cp:
+        def conv(a):
+            return cusig.convolve2d(a, kernel, mode="same", boundary="fill")
+    else:
+        def conv(a):
+            return sig.convolve2d(a, kernel, mode="same", boundary="fill")
+
+    def fd(a):
+        return finite_difference_laplacian(a, boundary="fill", xp=xp, kernel=kernel)
+
+    if xp is cp:
+        xp.cuda.Stream.null.synchronize()
+    t_conv = _time_fn(conv, arr, steps)
+    if xp is cp:
+        xp.cuda.Stream.null.synchronize()
+    t_fd = _time_fn(fd, arr, steps)
+    if xp is cp:
+        xp.cuda.Stream.null.synchronize()
+
+    print(f"backend={backend} size={n} steps={steps}")
+    print(f"  convolve2d: {t_conv:.4f}s")
+    print(f"  finite diff: {t_fd:.4f}s")
+
+
+if __name__ == "__main__":
+    benchmark()

--- a/wave_sim/core/kernels.py
+++ b/wave_sim/core/kernels.py
@@ -11,3 +11,62 @@ def get_laplacian_kernel(xp=np):
     """Return laplacian kernel as array for the given array module."""
     return xp.asarray(LAPLACIAN_KERNEL)
 
+
+def finite_difference_laplacian(u, boundary="fill", xp=np, kernel=None):
+    """Apply a 3x3 Laplacian stencil via ``xp.pad``/``xp.roll``.
+
+    Parameters
+    ----------
+    u : array-like
+        2-D field to operate on.
+    boundary : {"fill", "wrap", "symm"}, optional
+        How to treat values outside the domain. ``fill`` pads with zeros,
+        ``wrap`` implements periodic boundaries and ``symm`` mirrors the
+        array.
+    xp : module, optional
+        Array module (:mod:`numpy` or :mod:`cupy`).
+
+    Returns
+    -------
+    array-like
+        Laplacian of ``u`` with the same shape as ``u``.
+    """
+
+    if kernel is None:
+        k = get_laplacian_kernel(xp)
+    else:
+        k = kernel
+
+    if boundary == "wrap":
+        # periodic boundaries allow an efficient roll-based stencil
+        return (
+            k[1, 1] * u
+            + k[0, 1] * xp.roll(u, -1, axis=0)
+            + k[2, 1] * xp.roll(u, 1, axis=0)
+            + k[1, 0] * xp.roll(u, -1, axis=1)
+            + k[1, 2] * xp.roll(u, 1, axis=1)
+            + k[0, 0] * xp.roll(xp.roll(u, -1, axis=0), -1, axis=1)
+            + k[0, 2] * xp.roll(xp.roll(u, -1, axis=0), 1, axis=1)
+            + k[2, 0] * xp.roll(xp.roll(u, 1, axis=0), -1, axis=1)
+            + k[2, 2] * xp.roll(xp.roll(u, 1, axis=0), 1, axis=1)
+        )
+
+    if boundary == "symm":
+        pad_mode = "symmetric"
+    else:
+        pad_mode = "constant"
+
+    up = xp.pad(u, 1, mode=pad_mode)
+    return (
+        k[0, 0] * up[:-2, :-2]
+        + k[0, 1] * up[:-2, 1:-1]
+        + k[0, 2] * up[:-2, 2:]
+        + k[1, 0] * up[1:-1, :-2]
+        + k[1, 1] * up[1:-1, 1:-1]
+        + k[1, 2] * up[1:-1, 2:]
+        + k[2, 0] * up[2:, :-2]
+        + k[2, 1] * up[2:, 1:-1]
+        + k[2, 2] * up[2:, 2:]
+    )
+
+

--- a/wave_sim/high_quality/simulator.py
+++ b/wave_sim/high_quality/simulator.py
@@ -1,10 +1,9 @@
 import numpy as np
 import warnings
-import scipy.signal
 
 from ..backend import get_array_module
 from ..core.boundary import BoundaryCondition
-from ..core.kernels import get_laplacian_kernel
+from ..core.kernels import get_laplacian_kernel, finite_difference_laplacian
 
 
 class SceneObject:
@@ -113,17 +112,9 @@ class WaveSimulator2D:
             bmode = "symm"
         else:
             bmode = "fill"
-        if xp.__name__ == "cupy":
-            import cupyx.scipy.signal  # type: ignore
-            laplacian = xp.asarray(
-                cupyx.scipy.signal.convolve2d(
-                    self.u, self.laplacian_kernel, mode="same", boundary=bmode
-                )
-            )
-        else:
-            laplacian = scipy.signal.convolve2d(
-                self.u, self.laplacian_kernel, mode="same", boundary=bmode
-            )
+        laplacian = finite_difference_laplacian(
+            self.u, boundary=bmode, xp=xp, kernel=self.laplacian_kernel
+        )
         v = (self.u - self.u_prev) * self.d * self.global_dampening
         r = self.u + v + laplacian * (self.c * self.dt / self.dx) ** 2
         if self.boundary == BoundaryCondition.ABSORBING and self.sponge_thickness > 0:


### PR DESCRIPTION
## Summary
- implement a finite-difference Laplacian using `xp.pad`/`xp.roll`
- use the new stencil in `WaveSimulator2D`
- add a benchmark script to compare with the old `convolve2d` version

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*