### PR TITLE
Implement surface/interface wave solvers

### DIFF
--- a/examples/lamb_modes.py
+++ b/examples/lamb_modes.py
@@ -1,0 +1,22 @@
+"""Demonstrate Lamb S0 and A0 mode solvers."""
+
+from wave_sim.wave_catalog import LambS0Mode, LambA0Mode
+
+
+def run_s0(steps: int = 10):
+    sim = LambS0Mode()
+    for _ in range(steps):
+        sim.step()
+    return sim.get_displacement()
+
+
+def run_a0(steps: int = 10):
+    sim = LambA0Mode()
+    for _ in range(steps):
+        sim.step()
+    return sim.get_displacement()
+
+
+if __name__ == "__main__":
+    run_s0()
+    run_a0()

--- a/examples/love_surface_wave.py
+++ b/examples/love_surface_wave.py
@@ -1,0 +1,15 @@
+"""Love wave demo using the new solver."""
+
+from wave_sim.wave_catalog import LoveWave
+
+
+def generate_animation(steps: int = 10):
+    """Run a short demo returning displacement."""
+    sim = LoveWave()
+    for _ in range(steps):
+        sim.step()
+    return sim.get_displacement()
+
+
+if __name__ == "__main__":
+    generate_animation()

--- a/examples/rayleigh_surface_wave.py
+++ b/examples/rayleigh_surface_wave.py
@@ -1,13 +1,13 @@
-"""Rayleigh surface wave example using the elastic solver."""
+"""Rayleigh surface wave example using the new solver."""
 
-from wave_sim.elastic2d import rayleigh_surface_demo
+from wave_sim.wave_catalog import RayleighWave
 
 
 def generate_animation(steps: int = 10):
     """Run a short demo returning final displacement field."""
-    sim = rayleigh_surface_demo()
+    sim = RayleighWave()
     for _ in range(steps):
-        sim.update_field()
+        sim.step()
     return sim.get_displacement()
 
 

--- a/examples/scholte_interface_wave.py
+++ b/examples/scholte_interface_wave.py
@@ -1,0 +1,14 @@
+"""Scholte wave demonstration."""
+
+from wave_sim.wave_catalog import ScholteWave
+
+
+def generate_animation(steps: int = 10):
+    sim = ScholteWave()
+    for _ in range(steps):
+        sim.step()
+    return sim.get_displacement()
+
+
+if __name__ == "__main__":
+    generate_animation()

--- a/examples/stoneley_interface_wave.py
+++ b/examples/stoneley_interface_wave.py
@@ -1,0 +1,14 @@
+"""Stoneley wave demonstration."""
+
+from wave_sim.wave_catalog import StoneleyWave
+
+
+def generate_animation(steps: int = 10):
+    sim = StoneleyWave()
+    for _ in range(steps):
+        sim.step()
+    return sim.get_displacement()
+
+
+if __name__ == "__main__":
+    generate_animation()

--- a/tests/test_surface_interface_waves.py
+++ b/tests/test_surface_interface_waves.py
@@ -1,0 +1,52 @@
+import numpy as np
+import types
+import sys
+
+# minimal dummy cv2 to satisfy imports
+if 'cv2' not in sys.modules:
+    sys.modules['cv2'] = types.SimpleNamespace(circle=lambda *a, **k: None,
+                                              fillPoly=lambda *a, **k: None,
+                                              line=lambda *a, **k: None,
+                                              getRotationMatrix2D=lambda *a, **k: np.eye(2,3),
+                                              transform=lambda arr, mat: arr)
+
+from wave_sim.wave_catalog import (
+    RayleighWave,
+    LoveWave,
+    LambS0Mode,
+    LambA0Mode,
+    StoneleyWave,
+    ScholteWave,
+)
+
+
+def _check_energy(solver, steps=3, rtol=1e-3):
+    e0 = solver.energy()
+    for _ in range(steps):
+        solver.step()
+    e1 = solver.energy()
+    assert np.isclose(e0, e1, rtol=rtol)
+
+
+def test_rayleigh_energy():
+    _check_energy(RayleighWave())
+
+
+def test_love_energy():
+    _check_energy(LoveWave())
+
+
+def test_lamb_s0_energy():
+    _check_energy(LambS0Mode())
+
+
+def test_lamb_a0_energy():
+    _check_energy(LambA0Mode())
+
+
+def test_stoneley_energy():
+    _check_energy(StoneleyWave())
+
+
+def test_scholte_energy():
+    _check_energy(ScholteWave())


### PR DESCRIPTION
## Summary
- add a minimal scalar 2‑D wave solver and use it for Love waves
- implement new Rayleigh, Lamb, Stoneley and Scholte wave solvers using `ElasticWaveSimulator2D`
- provide small demonstration functions in examples
- create regression tests that check energy conservation for the new solvers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*