### PR TITLE
Add primary and secondary wave solvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
-This repository contains a simple 2‑D wave simulation that writes an mp4 file.
+This repository contains a simple 2‑D wave simulation.
 
 ## Usage
 
 Run the simulation from the command line:
 
 ```bash
-python main.py [--gpu] [--steps N] [--output PATH]
+python main.py [--steps N] [--output PATH] [--wave TYPE]
 ```
 
-- `--gpu` enables GPU acceleration via CuPy when available.
 - `--steps` controls the number of simulation steps (default: 19).
-- `--output` sets the path to the generated video.
+- `--output` sets the path to the generated video for the baseline solver.
+- `--wave` selects which solver to run: `baseline` (default), `p` (P-wave), or `s` (S-wave).
 
-If CuPy or a compatible GPU is not present, the code falls back to NumPy.
+The baseline solver produces an MP4 animation using `matplotlib`. The P- and S-wave
+solvers run purely in NumPy and report the final amplitude at the source location.

--- a/main.py
+++ b/main.py
@@ -1,12 +1,24 @@
-from wave_sim.simulation import run_simulation
+from wave_sim import run_simulation, solve_p_wave, solve_s_wave
 import argparse
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run the wave simulation")
-    parser.add_argument("--steps", type=int, default=19, help="Number of simulation steps")
-    parser.add_argument("--output", default="wave_2d.mp4", help="Output video path")
+    parser.add_argument("--steps", type=int, default=19,
+                        help="Number of simulation steps")
+    parser.add_argument("--output", default="wave_2d.mp4",
+                        help="Output video path (baseline only)")
+    parser.add_argument(
+        "--wave", choices=["baseline", "p", "s"], default="baseline",
+        help="Select which wave solver to run")
     args = parser.parse_args()
 
-    out = run_simulation(out_path=args.output, steps=args.steps)
-    print(f"Saved -> {out}")
+    if args.wave == "baseline":
+        out = run_simulation(out_path=args.output, steps=args.steps)
+        print(f"Saved -> {out}")
+    elif args.wave == "p":
+        snapshots, field = solve_p_wave(nt=args.steps)
+        print("P-wave simulation complete. Final amplitude:", field[field.shape[0] // 2, field.shape[1] // 2])
+    else:  # args.wave == "s"
+        snapshots, field = solve_s_wave(nt=args.steps)
+        print("S-wave simulation complete. Final amplitude:", field[field.shape[0] // 2, field.shape[1] // 2])

--- a/wave_sim/__init__.py
+++ b/wave_sim/__init__.py
@@ -1,0 +1,10 @@
+"""Wave simulation utilities."""
+
+from .simulation import run_simulation
+from .wave_equations import solve_p_wave, solve_s_wave
+
+__all__ = [
+    "run_simulation",
+    "solve_p_wave",
+    "solve_s_wave",
+]

--- a/wave_sim/wave_equations.py
+++ b/wave_sim/wave_equations.py
@@ -1,0 +1,96 @@
+import numpy as np
+
+
+def ricker_wavelet(t: float, f0: float) -> float:
+    """Return Ricker wavelet value at time ``t`` for peak frequency ``f0``."""
+    tau = 1.0 / f0
+    arg = np.pi * f0 * (t - tau)
+    return (1.0 - 2.0 * arg ** 2) * np.exp(-arg ** 2)
+
+
+def solve_p_wave(nx: int = 200, nz: int = 200, dx: float = 5.0, dz: float = 5.0,
+                 alpha: float = 3000.0, dt: float = 0.0005, nt: int = 750,
+                 f0: float = 15.0):
+    """Compute a 2-D P-wave field using a simple finite difference solver.
+
+    Parameters
+    ----------
+    nx, nz : int
+        Number of grid points in the x and z directions.
+    dx, dz : float
+        Grid spacing in meters.
+    alpha : float
+        P-wave speed.
+    dt : float
+        Time step in seconds.
+    nt : int
+        Number of time steps to simulate.
+    f0 : float
+        Peak frequency of the Ricker wavelet source.
+
+    Returns
+    -------
+    list[np.ndarray]
+        Snapshot wave fields taken every 50 steps.
+    np.ndarray
+        Final wave field array of shape ``(nx, nz)``.
+    """
+    P_now = np.zeros((nx, nz))
+    P_prev = np.zeros((nx, nz))
+    P_next = np.zeros((nx, nz))
+
+    sx, sz = nx // 2, nz // 2
+
+    snapshots = []
+
+    for it in range(nt):
+        for i in range(1, nx - 1):
+            for j in range(1, nz - 1):
+                lap = (
+                    (P_now[i + 1, j] - 2.0 * P_now[i, j] + P_now[i - 1, j]) / dx ** 2
+                    + (P_now[i, j + 1] - 2.0 * P_now[i, j] + P_now[i, j - 1]) / dz ** 2
+                )
+                P_next[i, j] = (
+                    2.0 * P_now[i, j] - P_prev[i, j] + alpha ** 2 * dt ** 2 * lap
+                )
+
+        P_next[sx, sz] += ricker_wavelet(it * dt, f0)
+
+        P_prev, P_now, P_next = P_now, P_next, P_prev
+
+        if it % 50 == 0:
+            snapshots.append(P_now.copy())
+
+    return snapshots, P_now
+
+
+def solve_s_wave(nx: int = 200, nz: int = 200, dx: float = 5.0, dz: float = 5.0,
+                 beta: float = 1500.0, dt: float = 0.0005, nt: int = 750,
+                 f0: float = 15.0):
+    """Compute a 2-D S-wave field using a simple finite difference solver."""
+    S_now = np.zeros((nx, nz))
+    S_prev = np.zeros((nx, nz))
+    S_next = np.zeros((nx, nz))
+
+    sx, sz = nx // 2, nz // 2
+    snapshots = []
+
+    for it in range(nt):
+        for i in range(1, nx - 1):
+            for j in range(1, nz - 1):
+                lap = (
+                    (S_now[i + 1, j] - 2.0 * S_now[i, j] + S_now[i - 1, j]) / dx ** 2
+                    + (S_now[i, j + 1] - 2.0 * S_now[i, j] + S_now[i, j - 1]) / dz ** 2
+                )
+                S_next[i, j] = (
+                    2.0 * S_now[i, j] - S_prev[i, j] + beta ** 2 * dt ** 2 * lap
+                )
+
+        S_next[sx, sz] += ricker_wavelet(it * dt, f0)
+
+        S_prev, S_now, S_next = S_now, S_next, S_prev
+
+        if it % 50 == 0:
+            snapshots.append(S_now.copy())
+
+    return snapshots, S_now


### PR DESCRIPTION
## Summary
- provide new `solve_p_wave` and `solve_s_wave` functions with simple finite difference solvers
- expose the new solvers via `wave_sim.__all__`
- update CLI to choose between the baseline, P-wave and S-wave solvers
- document the new `--wave` option

## Testing
- `python -m py_compile wave_sim/wave_equations.py main.py wave_sim/__init__.py`
- ❌ `python main.py --wave p --steps 10` *(fails: ModuleNotFoundError: No module named 'numpy')*