### PR TITLE
Add periodic simulation logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,17 @@ This repository contains a simple 2‑D wave simulation that writes an mp4 file.
 Run the simulation from the command line:
 
 ```bash
-python main.py [--gpu] [--steps N] [--output PATH]
+python main.py [--gpu] [--steps N] [--output PATH] [--log_interval M]
 ```
 
 - `--gpu` enables GPU acceleration via CuPy when available.
-- `--steps` controls the number of simulation steps (default: 19).
+- `--steps` controls the number of simulation steps (default: 20).
 - `--output` sets the path to the generated video.
+- `--log_interval` controls how often simulation metrics are written to the log
+  file (in steps).
 
 If CuPy or a compatible GPU is not present, the code falls back to NumPy.
+
+Each run creates a log file under the `logs/` directory named with the
+timestamp of when the simulation started. The log records the time, velocity,
+amplitude, and energy at the specified interval.

--- a/main.py
+++ b/main.py
@@ -6,7 +6,10 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run the wave simulation")
     parser.add_argument("--steps", type=int, default=20, help="Number of simulation steps")
     parser.add_argument("--output", default="wave_2d.mp4", help="Output video path")
+    parser.add_argument("--log_interval", type=int, default=5,
+                        help="Interval (in steps) between log entries")
     args = parser.parse_args()
 
-    out = run_simulation(out_path=args.output, steps=args.steps)
+    out = run_simulation(out_path=args.output, steps=args.steps,
+                         log_interval=args.log_interval)
     print(f"Saved -> {out}")


### PR DESCRIPTION
## Summary
- implement logging in `run_simulation`
- expose `--log_interval` CLI arg
- document the new option and log files in `README`

## Testing
- `python -m py_compile main.py wave_sim/*.py`
- *(fails: ModuleNotFoundError: No module named 'numpy' when attempting to run `python main.py --steps 2 --output test.mp4 --log_interval 1`)*