### PR TITLE
Add P and S wave simulation options

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,8 +8,40 @@ if __name__ == "__main__":
     parser.add_argument("--output", default="wave_2d.mp4", help="Output video path")
     parser.add_argument("--log_interval", type=int, default=5,
                         help="Interval (in steps) between log entries")
+
+    parser.add_argument(
+        "--wave_type",
+        type=str,
+        default="acoustic",
+        choices=["acoustic", "P", "S_SH", "S_SV_potential"],
+        help=(
+            "Type of wave to simulate: 'acoustic', 'P' for P-wave potential, "
+            "'S_SH' for shear horizontal displacement, or 'S_SV_potential' "
+            "for shear vertical wave potential."
+        ),
+    )
+    parser.add_argument(
+        "--c_acoustic", type=float, default=1.0,
+        help="Wave speed for the basic acoustic simulation"
+    )
+    parser.add_argument(
+        "--vp", type=float, default=2.0,
+        help="P-wave velocity when simulating P-waves"
+    )
+    parser.add_argument(
+        "--vs", type=float, default=1.0,
+        help="S-wave velocity when simulating S-waves"
+    )
+
     args = parser.parse_args()
 
-    out = run_simulation(out_path=args.output, steps=args.steps,
-                         log_interval=args.log_interval)
+    out = run_simulation(
+        out_path=args.output,
+        steps=args.steps,
+        log_interval=args.log_interval,
+        wave_type=args.wave_type,
+        c_acoustic=args.c_acoustic,
+        vp=args.vp,
+        vs=args.vs,
+    )
     print(f"Saved -> {out}")


### PR DESCRIPTION
## Summary
- extend CLI options for wave type and velocities
- support P and S wave modes in simulation logic
- track wave type in logs and fix energy computation
- generalise visualiser labels for different wave fields

## Testing
- `python main.py --steps 1 --wave_type acoustic --output tmp.mp4` *(fails: ModuleNotFoundError: No module named 'numpy')*