### PR TITLE
Implement elastic wave potential solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ Example: run a P-wave simulation for 100 steps
 python main.py --wave_type P --steps 100 --output p_wave.mp4
 ```
 
+### Elastic potentials demo
+
+The module `wave_sim.elastic_waves` now includes a helper function
+`simulate_elastic_potentials` that evolves coupled P- and S-wave potentials and
+returns the corresponding displacement fields. This routine illustrates a more
+complete elastic formulation where both wave modes propagate simultaneously.
+
 ## Output Files
 
 The program writes the MP4 animation specified by `--output`.  A log file containing ring‑average metrics is also generated in the `logs/` directory with a timestamped name such as `simulation_acoustic_YYYYMMDD_HHMMSS.log`.

--- a/wave_sim/__init__.py
+++ b/wave_sim/__init__.py
@@ -1,11 +1,16 @@
 """Wave simulation utilities."""
 
 from .simulation import run_simulation
-from .elastic_waves import simulate_p_wave, simulate_s_wave
+from .elastic_waves import (
+    simulate_p_wave,
+    simulate_s_wave,
+    simulate_elastic_potentials,
+)
 
 __all__ = [
     "run_simulation",
     "simulate_p_wave",
     "simulate_s_wave",
+    "simulate_elastic_potentials",
 ]
 

--- a/wave_sim/elastic_waves.py
+++ b/wave_sim/elastic_waves.py
@@ -140,3 +140,136 @@ def simulate_s_wave(
             snaps.append(s_now.copy())
 
     return s_now, snaps
+
+# ---------------------------------------------------------------------------
+# Full elastic solver using P and S wave potentials
+# ---------------------------------------------------------------------------
+def simulate_elastic_potentials(
+    nx: int = 200,
+    nz: int = 200,
+    dx: float = 5.0,
+    dz: float = 5.0,
+    vp: float = 3000.0,
+    vs: float = 1500.0,
+    dt: float | None = None,
+    nt: int = 750,
+    f0: float = 15.0,
+    source: str = "P",
+):
+    """Simulate 2-D elastic wave propagation via scalar potentials.
+
+    The solver evolves a P-wave potential ``phi`` and an S-wave potential ``psi``
+    according to the coupled potential formulation of isotropic elasticity::
+
+        phi_tt = vp^2 * (phi_xx + phi_zz)
+        psi_tt = vs^2 * (psi_xx + psi_zz)
+
+    Displacements ``u_x`` and ``u_z`` are recovered from the potentials via
+
+        u_x = dphi_dx - dpsi_dz
+        u_z = dphi_dz + dpsi_dx
+
+    Parameters
+    ----------
+    nx, nz : int
+        Number of grid points in the ``x`` and ``z`` directions.
+    dx, dz : float
+        Grid spacing (metres).
+    vp, vs : float
+        P-wave and S-wave speeds.
+    dt : float, optional
+        Time step size.  If ``None`` a stable value based on ``vp`` is chosen.
+    nt : int
+        Number of time steps to simulate.
+    f0 : float
+        Peak frequency of the Ricker source wavelet.
+    source : {'P', 'S', 'both'}
+        Which potential receives the source term.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        Final displacement fields ``(u_x, u_z)``.
+    list[tuple[np.ndarray, np.ndarray]]
+        Displacement snapshots every 50 steps.
+    """
+    if dt is None:
+        cfl = 0.7
+        dt = cfl * min(dx, dz) / max(vp, vs)
+
+    phi_now = np.zeros((nx, nz), dtype=float)
+    phi_prev = np.zeros_like(phi_now)
+    phi_next = np.zeros_like(phi_now)
+
+    psi_now = np.zeros((nx, nz), dtype=float)
+    psi_prev = np.zeros_like(psi_now)
+    psi_next = np.zeros_like(psi_now)
+
+    ux = np.zeros((nx, nz), dtype=float)
+    uz = np.zeros((nx, nz), dtype=float)
+
+    sx, sz = nx // 2, nz // 2
+    snaps: list[tuple[np.ndarray, np.ndarray]] = []
+
+    vp2_dt2 = (vp * dt) ** 2
+    vs2_dt2 = (vs * dt) ** 2
+
+    for it in range(nt):
+        # update phi potential
+        for i in range(1, nx - 1):
+            for j in range(1, nz - 1):
+                lap_phi = (
+                    (phi_now[i + 1, j] - 2.0 * phi_now[i, j] + phi_now[i - 1, j]) / dx ** 2
+                    + (
+                        phi_now[i, j + 1]
+                        - 2.0 * phi_now[i, j]
+                        + phi_now[i, j - 1]
+                    )
+                    / dz ** 2
+                )
+                phi_next[i, j] = 2.0 * phi_now[i, j] - phi_prev[i, j] + vp2_dt2 * lap_phi
+
+        # update psi potential
+        for i in range(1, nx - 1):
+            for j in range(1, nz - 1):
+                lap_psi = (
+                    (psi_now[i + 1, j] - 2.0 * psi_now[i, j] + psi_now[i - 1, j]) / dx ** 2
+                    + (
+                        psi_now[i, j + 1]
+                        - 2.0 * psi_now[i, j]
+                        + psi_now[i, j - 1]
+                    )
+                    / dz ** 2
+                )
+                psi_next[i, j] = 2.0 * psi_now[i, j] - psi_prev[i, j] + vs2_dt2 * lap_psi
+
+        src_val = ricker_wavelet(it * dt, f0)
+        if source in ("P", "both"):
+            phi_next[sx, sz] += src_val
+        if source in ("S", "both"):
+            psi_next[sx, sz] += src_val
+
+        phi_prev, phi_now, phi_next = phi_now, phi_next, phi_prev
+        psi_prev, psi_now, psi_next = psi_now, psi_next, psi_prev
+
+        if it % 50 == 0:
+            # compute displacements from current potentials
+            dphi_dx = (phi_now[2:, 1:-1] - phi_now[:-2, 1:-1]) / (2 * dx)
+            dphi_dz = (phi_now[1:-1, 2:] - phi_now[1:-1, :-2]) / (2 * dz)
+            dpsi_dx = (psi_now[2:, 1:-1] - psi_now[:-2, 1:-1]) / (2 * dx)
+            dpsi_dz = (psi_now[1:-1, 2:] - psi_now[1:-1, :-2]) / (2 * dz)
+
+            ux[1:-1, 1:-1] = dphi_dx - dpsi_dz
+            uz[1:-1, 1:-1] = dphi_dz + dpsi_dx
+            snaps.append((ux.copy(), uz.copy()))
+
+    # final displacement
+    dphi_dx = (phi_now[2:, 1:-1] - phi_now[:-2, 1:-1]) / (2 * dx)
+    dphi_dz = (phi_now[1:-1, 2:] - phi_now[1:-1, :-2]) / (2 * dz)
+    dpsi_dx = (psi_now[2:, 1:-1] - psi_now[:-2, 1:-1]) / (2 * dx)
+    dpsi_dz = (psi_now[1:-1, 2:] - psi_now[1:-1, :-2]) / (2 * dz)
+
+    ux[1:-1, 1:-1] = dphi_dx - dpsi_dz
+    uz[1:-1, 1:-1] = dphi_dz + dpsi_dx
+
+    return (ux, uz), snaps


### PR DESCRIPTION
## Summary
- expose a new `simulate_elastic_potentials` routine
- document the new elastic wave solver in the README
- export the routine from `wave_sim.__init__`

## Testing
- `python -m py_compile $(git ls-files '*.py')`