### PR TITLE
Enhance elastic solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ python main.py --steps 60 --output wave_2d.mp4
 --f0           Source peak frequency
 --absorb_width Damping layer width (cells)
 --absorb_strength Damping strength coefficient
+--elastic_source P | S | both    Source type for elastic solver
 ```
 
 Example: run a P-wave simulation for 100 steps
@@ -79,6 +80,8 @@ conjugate–gradient solver. Scalar wave modes use the same Ricker time function
 at the centre by default.
 All dynamic solvers support a simple absorbing boundary implemented as an
 exponential damping layer controlled by `--absorb_width` and `--absorb_strength`.
+The `--elastic_source` option selects whether the elastic solver injects a pure
+P source, a pure S source, or both.
 
 ## Output Files
 

--- a/main.py
+++ b/main.py
@@ -39,6 +39,7 @@ if __name__ == "__main__":
     parser.add_argument("--f0", type=float, default=25.0)
     parser.add_argument("--absorb_width", type=int, default=10)
     parser.add_argument("--absorb_strength", type=float, default=2.0)
+    parser.add_argument("--elastic_source", type=str, default="P", choices=["P", "S", "both"])
 
     args = parser.parse_args()
 
@@ -54,6 +55,7 @@ if __name__ == "__main__":
         f0=args.f0,
         absorb_width=args.absorb_width,
         absorb_strength=args.absorb_strength,
+        elastic_source=args.elastic_source,
         vp=args.vp,
         vs=args.vs,
     )

--- a/wave_sim/elastic_waves.py
+++ b/wave_sim/elastic_waves.py
@@ -225,33 +225,24 @@ def simulate_elastic_potentials(
     vs2_dt2 = (vs * dt) ** 2
 
     for it in range(nt):
-        # update phi potential
-        for i in range(1, nx - 1):
-            for j in range(1, nz - 1):
-                lap_phi = (
-                    (phi_now[i + 1, j] - 2.0 * phi_now[i, j] + phi_now[i - 1, j]) / dx ** 2
-                    + (
-                        phi_now[i, j + 1]
-                        - 2.0 * phi_now[i, j]
-                        + phi_now[i, j - 1]
-                    )
-                    / dz ** 2
-                )
-                phi_next[i, j] = 2.0 * phi_now[i, j] - phi_prev[i, j] + vp2_dt2 * lap_phi
+        lap_phi = (
+            phi_now[2:, 1:-1] + phi_now[:-2, 1:-1] - 2.0 * phi_now[1:-1, 1:-1]
+        ) / dx ** 2 + (
+            phi_now[1:-1, 2:] + phi_now[1:-1, :-2] - 2.0 * phi_now[1:-1, 1:-1]
+        ) / dz ** 2
+        lap_psi = (
+            psi_now[2:, 1:-1] + psi_now[:-2, 1:-1] - 2.0 * psi_now[1:-1, 1:-1]
+        ) / dx ** 2 + (
+            psi_now[1:-1, 2:] + psi_now[1:-1, :-2] - 2.0 * psi_now[1:-1, 1:-1]
+        ) / dz ** 2
 
-        # update psi potential
-        for i in range(1, nx - 1):
-            for j in range(1, nz - 1):
-                lap_psi = (
-                    (psi_now[i + 1, j] - 2.0 * psi_now[i, j] + psi_now[i - 1, j]) / dx ** 2
-                    + (
-                        psi_now[i, j + 1]
-                        - 2.0 * psi_now[i, j]
-                        + psi_now[i, j - 1]
-                    )
-                    / dz ** 2
-                )
-                psi_next[i, j] = 2.0 * psi_now[i, j] - psi_prev[i, j] + vs2_dt2 * lap_psi
+        phi_next[1:-1, 1:-1] = (
+            2.0 * phi_now[1:-1, 1:-1] - phi_prev[1:-1, 1:-1] + vp2_dt2 * lap_phi
+        )
+
+        psi_next[1:-1, 1:-1] = (
+            2.0 * psi_now[1:-1, 1:-1] - psi_prev[1:-1, 1:-1] + vs2_dt2 * lap_psi
+        )
 
         src_val = ricker_wavelet(it * dt, f0)
         if source in ("P", "both"):

--- a/wave_sim/simulation.py
+++ b/wave_sim/simulation.py
@@ -25,6 +25,7 @@ def run_simulation(
         f0=25.0,
         absorb_width=10,
         absorb_strength=2.0,
+        elastic_source="P",
 ):
     L = 2.0
     dx = 0.01
@@ -100,6 +101,7 @@ def run_simulation(
             ring_radius=ring_radius,
             absorb_width=absorb_width,
             absorb_strength=absorb_strength,
+            source=elastic_source,
         )
         viz = WaveVisualizer(
             sim_shape=field_snaps[0].shape,
@@ -153,7 +155,7 @@ def run_simulation(
             dt=dt,
             nt=steps,
             f0=f0,
-            source="both",
+            source=elastic_source,
             absorb_width=absorb_width,
             absorb_strength=absorb_strength,
         )

--- a/wave_sim/vector_elastic.py
+++ b/wave_sim/vector_elastic.py
@@ -26,6 +26,7 @@ def simulate_elastic_wave(
     ring_radius: float = 0.15,
     absorb_width: int = 10,
     absorb_strength: float = 2.0,
+    source: str = "P",
 ):
     npts = int(L / dx) + 1
     x = np.arange(npts) * dx
@@ -80,8 +81,11 @@ def simulate_elastic_wave(
         sxy *= damping
 
         src_val = ricker_wavelet(it * dt, f0)
-        sxx[src_i, src_j] += src_val
-        syy[src_i, src_j] += src_val
+        if source in ("P", "both"):
+            sxx[src_i, src_j] += src_val
+            syy[src_i, src_j] += src_val
+        if source in ("S", "both"):
+            sxy[src_i, src_j] += src_val
 
         dsxx_dx = (sxx[2:, 1:-1] - sxx[:-2, 1:-1]) / (2 * dx)
         dsxy_dy = (sxy[1:-1, 2:] - sxy[1:-1, :-2]) / (2 * dx)


### PR DESCRIPTION
## Summary
- add `elastic_source` option for choosing P, S, or both source types
- support new option in CLI
- vectorize `simulate_elastic_potentials` for better performance
- expose source option when running elastic solver
- document the new option in the README

## Testing
- `python -m py_compile main.py wave_sim/*.py`
- *(fails: ModuleNotFoundError: No module named 'numpy' when running main)*